### PR TITLE
GIE-226: Add LLM-friendly errors and handle empty response cases

### DIFF
--- a/pkg/mcp/handlers.go
+++ b/pkg/mcp/handlers.go
@@ -125,7 +125,7 @@ func ExecuteRangeQueryHandler(opts ObsMCPOptions) func(context.Context, mcp.Call
 		// Execute the range query
 		result, err := promClient.ExecuteRangeQuery(ctx, query, startTime, endTime, time.Duration(stepDuration))
 		if err != nil {
-			// Pass through the error directly as it's already LLM-friendly from the loader
+			// Pass through the error directly as it's already LLM-friendly from the loader/guardrails
 			return errorResult(err.Error())
 		}
 

--- a/pkg/prometheus/guardrails.go
+++ b/pkg/prometheus/guardrails.go
@@ -82,22 +82,97 @@ func ParseGuardrails(value string) (*Guardrails, error) {
 
 // IsSafeQuery analyzes a PromQL query string and returns false if it's
 // deemed unsafe or too expensive based on the configured rules.
-// If client is provided and MaxMetricCardinality is set, it checks TSDB metric cardinality.
-// If client is provided and MaxLabelCardinality is set, it checks TSDB label cardinality for blanket regex.
 //
-// Returns (false, error) if the query is invalid or violates a guardrail rule.
+// Non-optional checks (always enforced):
+//   - Metric existence validation: Ensures queried metrics exist in TSDB
+//
+// Optional checks (based on Guardrails configuration):
+//   - DisallowExplicitNameLabel: Prevents queries using explicit {__name__="..."} syntax
+//   - RequireLabelMatcher: Ensures all vector selectors have at least one non-name label matcher
+//   - MaxMetricCardinality: Checks TSDB metric cardinality limits
+//   - DisallowBlanketRegex: Prevents expensive regex patterns like .* or .+
+//   - MaxLabelCardinality: Checks TSDB label cardinality for blanket regex
+//
+// Returns (false, error) if the query is invalid or violates any rule.
 // The error message explains which rule was violated.
 // Returns (true, nil) if the query is valid and passes all rules.
 //
 //nolint:gocyclo // complex validation logic, refactoring would reduce readability
 func (g *Guardrails) IsSafeQuery(ctx context.Context, query string, client v1.API) (bool, error) {
-	if ((g.DisallowBlanketRegex && g.MaxLabelCardinality > 0) || (g.MaxMetricCardinality > 0)) && (client == nil || ctx == nil) {
-		return false, fmt.Errorf("cannot verify cardinality without TSDB client")
+	// Always require client and context for TSDB checks (including metric existence validation)
+	if client == nil || ctx == nil {
+		return false, fmt.Errorf("cannot validate query safety: Prometheus client or context is not available. " +
+			"This is an internal configuration issue - please ensure the Prometheus client is properly initialized")
 	}
 
+	// NON-OPTIONAL CHECK: Parse and validate query syntax
 	expr, err := parser.ParseExpr(query)
 	if err != nil {
-		return false, fmt.Errorf("failed to parse query: %w", err)
+		return false, fmt.Errorf("the PromQL query '%s' has a syntax error. Error details: %w. "+
+			"Please check the query syntax and ensure all metric names, labels, and functions are correct, and properly formatted",
+			query, err)
+	}
+
+	// Early check: validate that queried metrics exist in TSDB
+	// Also fetch TSDB stats once for all subsequent cardinality checks
+	metricNames, err := ExtractMetricNames(query)
+	if err != nil {
+		return false, fmt.Errorf("failed to analyze the query '%s' to extract metric names. Error details: %w. "+
+			"This might indicate an issue with the query structure",
+			query, err)
+	}
+
+	var seriesCountByMetric map[string]uint64
+	var labelValueCountByLabel map[string]uint64
+
+	// Query TSDB once and reuse for all checks
+	tsdbResult, err := client.TSDB(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to retrieve metrics information from Prometheus TSDB. Error details: %w. "+
+			"Please verify that the Prometheus server is accessible and responding correctly",
+			err)
+	}
+
+	seriesCountByMetric = make(map[string]uint64)
+	for _, stat := range tsdbResult.SeriesCountByMetricName {
+		seriesCountByMetric[stat.Name] = stat.Value
+	}
+
+	labelValueCountByLabel = make(map[string]uint64)
+	for _, stat := range tsdbResult.LabelValueCountByLabelName {
+		labelValueCountByLabel[stat.Name] = stat.Value
+	}
+
+	// NON-OPTIONAL CHECK: Validate that all queried metrics exist in TSDB
+	// This check always runs regardless of guardrail configuration
+	if len(metricNames) > 0 {
+		for _, metricName := range metricNames {
+			count, exists := seriesCountByMetric[metricName]
+			if !exists || count == 0 {
+				return false, fmt.Errorf("the metric '%s' does not exist in Prometheus. "+
+					"You can use the 'list_metrics' tool to see all available metrics, or check if the metric name is spelled correctly",
+					metricName)
+			}
+		}
+	}
+
+	// NON-OPTIONAL CHECK: Validate that all queried labels exist in TSDB
+	labelNames, err := ExtractLabelNames(query)
+	if err != nil {
+		return false, fmt.Errorf("failed to analyze the query '%s' to extract label names. Error details: %w. "+
+			"This might indicate an issue with the query structure",
+			query, err)
+	}
+
+	if len(labelNames) > 0 {
+		for _, labelName := range labelNames {
+			if _, exists := labelValueCountByLabel[labelName]; !exists {
+				return false, fmt.Errorf("the label '%s' used in query '%s' does not exist in Prometheus. "+
+					"Please check if the label name is spelled correctly. "+
+					"Common labels include 'job', 'instance', etc. You may need to verify which labels are available for your metrics",
+					labelName, query)
+			}
+		}
 	}
 
 	var unsafeReason error
@@ -112,7 +187,9 @@ func (g *Guardrails) IsSafeQuery(ctx context.Context, query string, client v1.AP
 		if g.DisallowExplicitNameLabel && vs.Name == "" {
 			for _, m := range vs.LabelMatchers {
 				if m.Name == labels.MetricName {
-					unsafeReason = fmt.Errorf("query uses explicit __name__ label matcher, which is disallowed")
+					unsafeReason = fmt.Errorf("the query '%s' uses explicit {__name__=\"...\"} syntax, which is not allowed. "+
+						"Please use the direct metric name syntax instead (e.g., use 'metric_name{label=\"value\"}' instead of '{__name__=\"metric_name\",label=\"value\"}')",
+						query)
 					return unsafeReason
 				}
 			}
@@ -128,7 +205,10 @@ func (g *Guardrails) IsSafeQuery(ctx context.Context, query string, client v1.AP
 				}
 			}
 			if !hasNonNameMatcher {
-				unsafeReason = fmt.Errorf("query for metric %q does not have any label matchers, which is required", vs.Name)
+				unsafeReason = fmt.Errorf("the query for metric '%s' does not have any label filters, which is required for safety. "+
+					"Queries without label matchers can be very expensive as they return all series for a metric. "+
+					"Please add at least one label filter (e.g., '%s{job=\"...\"}' or '%s{instance=\"...\"}')",
+					vs.Name, vs.Name, vs.Name)
 				return unsafeReason
 			}
 		}
@@ -140,62 +220,47 @@ func (g *Guardrails) IsSafeQuery(ctx context.Context, query string, client v1.AP
 		return false, unsafeReason
 	}
 
-	// Check metric cardinality
-	if g.MaxMetricCardinality > 0 {
-		metricNames, err := ExtractMetricNames(query)
-		if err != nil {
-			return false, fmt.Errorf("failed to extract metric names: %w", err)
-		}
-
-		if len(metricNames) > 0 {
-			tsdbResult, err := client.TSDB(ctx)
-			if err != nil {
-				return false, fmt.Errorf("failed to get TSDB stats: %w", err)
-			}
-
-			seriesCountByMetric := make(map[string]uint64)
-			for _, stat := range tsdbResult.SeriesCountByMetricName {
-				seriesCountByMetric[stat.Name] = stat.Value
-			}
-
-			for _, metricName := range metricNames {
-				if count, exists := seriesCountByMetric[metricName]; exists {
-					if count > g.MaxMetricCardinality {
-						return false, fmt.Errorf("metric %q has cardinality %d, which exceeds maximum allowed %d", metricName, count, g.MaxMetricCardinality)
-					}
+	// Check metric cardinality (reuse TSDB data fetched earlier)
+	if g.MaxMetricCardinality > 0 && len(metricNames) > 0 {
+		for _, metricName := range metricNames {
+			if count, exists := seriesCountByMetric[metricName]; exists {
+				if count > g.MaxMetricCardinality {
+					return false, fmt.Errorf("the metric '%s' has %d time series, which exceeds the maximum allowed limit of %d. "+
+						"This metric has too many unique label combinations, making queries expensive. "+
+						"Please add more specific label filters to reduce the number of series returned, or use aggregation functions to reduce cardinality",
+						metricName, count, g.MaxMetricCardinality)
 				}
 			}
 		}
 	}
 
-	// Check blanket regex patterns
+	// Check blanket regex patterns (reuse TSDB data fetched earlier)
 	if g.DisallowBlanketRegex {
 		blanketRegexLabels, err := ExtractBlanketRegexLabels(query)
 		if err != nil {
-			return false, fmt.Errorf("failed to extract blanket regex labels: %w", err)
+			return false, fmt.Errorf("failed to analyze the query '%s' for regex patterns. Error details: %w. "+
+				"This might indicate an issue with the query structure",
+				query, err)
 		}
 
 		if len(blanketRegexLabels) > 0 {
 			// If MaxLabelCardinality is 0, always disallow blanket regex
 			if g.MaxLabelCardinality == 0 {
-				return false, fmt.Errorf("query uses blanket regex on label %q, which is disallowed", blanketRegexLabels[0])
+				return false, fmt.Errorf("the query '%s' uses a blanket regex pattern (=~ \".*\" or =~ \".+\") on label '%s', which is not allowed. "+
+					"Blanket regex patterns match all values and can be extremely expensive. "+
+					"Please use more specific label matchers or exact value matches instead",
+					query, blanketRegexLabels[0])
 			}
 
-			// Check TSDB label cardinality for blanket regex
-			tsdbResult, err := client.TSDB(ctx)
-			if err != nil {
-				return false, fmt.Errorf("failed to get TSDB stats: %w", err)
-			}
-
-			labelValueCountByLabel := make(map[string]uint64)
-			for _, stat := range tsdbResult.LabelValueCountByLabelName {
-				labelValueCountByLabel[stat.Name] = stat.Value
-			}
-
+			// Check label cardinality for blanket regex using already-fetched TSDB data
 			for _, labelName := range blanketRegexLabels {
 				if count, exists := labelValueCountByLabel[labelName]; exists {
 					if count > g.MaxLabelCardinality {
-						return false, fmt.Errorf("label %q has cardinality %d, which exceeds maximum allowed %d for blanket regex", labelName, count, g.MaxLabelCardinality)
+						return false, fmt.Errorf("the query '%s' uses a blanket regex pattern on label '%s', which has %d unique values. "+
+							"This exceeds the maximum allowed limit of %d for regex patterns. "+
+							"Blanket regex on high-cardinality labels is very expensive. "+
+							"Please use specific label values or more restrictive regex patterns instead",
+							query, labelName, count, g.MaxLabelCardinality)
 					}
 				}
 			}
@@ -203,6 +268,34 @@ func (g *Guardrails) IsSafeQuery(ctx context.Context, query string, client v1.AP
 	}
 
 	return true, nil
+}
+
+// MakeLLMFriendlyError converts Prometheus execution errors into more descriptive, LLM-friendly messages.
+// Note: Parse errors are handled in IsSafeQuery where the query is parsed.
+func MakeLLMFriendlyError(err error, query string) error {
+	if err == nil {
+		return nil
+	}
+
+	errMsg := err.Error()
+	lowerMsg := strings.ToLower(errMsg)
+
+	// Check for common error patterns and provide helpful context
+	switch {
+	case strings.Contains(lowerMsg, "timeout") || strings.Contains(lowerMsg, "deadline exceeded"):
+		return fmt.Errorf("the query '%s' took too long to execute and timed out. Error details: %w. "+
+			"This might happen if the query is too complex, the time range is too large, or the Prometheus server is under heavy load. "+
+			"Try reducing the time range, increasing the step size, or simplifying the query",
+			query, err)
+
+	case strings.Contains(lowerMsg, "no such host") || strings.Contains(lowerMsg, "connection refused"):
+		return fmt.Errorf("cannot connect to the Prometheus server. Error details: %w. "+
+			"Please verify that the Prometheus server is running and accessible", err)
+
+	default:
+		// Return error with query context for better debugging
+		return fmt.Errorf("query '%s' failed: %w", query, err)
+	}
 }
 
 func ExtractMetricNames(query string) ([]string, error) {
@@ -229,6 +322,33 @@ func ExtractMetricNames(query string) ([]string, error) {
 
 	result := make([]string, 0, len(metricNames))
 	for name := range metricNames {
+		result = append(result, name)
+	}
+	return result, nil
+}
+
+// ExtractLabelNames extracts all label names used in the query (excluding __name__).
+func ExtractLabelNames(query string) ([]string, error) {
+	expr, err := parser.ParseExpr(query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse query: %w", err)
+	}
+
+	labelNames := make(map[string]bool)
+	parser.Inspect(expr, func(node parser.Node, path []parser.Node) error {
+		if vs, ok := node.(*parser.VectorSelector); ok {
+			for _, m := range vs.LabelMatchers {
+				// Skip __name__ as it's the metric name, not a label
+				if m.Name != labels.MetricName {
+					labelNames[m.Name] = true
+				}
+			}
+		}
+		return nil
+	})
+
+	result := make([]string, 0, len(labelNames))
+	for name := range labelNames {
 		result = append(result, name)
 	}
 	return result, nil

--- a/pkg/prometheus/loader_test.go
+++ b/pkg/prometheus/loader_test.go
@@ -16,36 +16,6 @@ func TestMakeLLMFriendlyError(t *testing.T) {
 		expectedSubstr []string // substrings that should be in the error message
 	}{
 		{
-			name:          "parse error",
-			originalError: errors.New("parse error: unexpected character"),
-			query:         "up{invalid",
-			expectedSubstr: []string{
-				"syntax error",
-				"up{invalid",
-				"check the query syntax",
-			},
-		},
-		{
-			name:          "bad_data error",
-			originalError: errors.New("bad_data: invalid expression"),
-			query:         "rate(http[5m])",
-			expectedSubstr: []string{
-				"syntax error",
-				"rate(http[5m])",
-				"correctly formatted",
-			},
-		},
-		{
-			name:          "unknown function",
-			originalError: errors.New("unknown function: foobar"),
-			query:         "foobar(up)",
-			expectedSubstr: []string{
-				"unknown function",
-				"foobar(up)",
-				"function name is correct",
-			},
-		},
-		{
 			name:          "timeout error",
 			originalError: errors.New("query timeout exceeded"),
 			query:         "sum(rate(http_requests_total[5m])) by (job)",
@@ -97,7 +67,7 @@ func TestMakeLLMFriendlyError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := makeLLMFriendlyError(tt.originalError, tt.query)
+			result := MakeLLMFriendlyError(tt.originalError, tt.query)
 			if result == nil {
 				t.Fatalf("expected error, got nil")
 			}
@@ -113,7 +83,7 @@ func TestMakeLLMFriendlyError(t *testing.T) {
 }
 
 func TestMakeLLMFriendlyError_NilError(t *testing.T) {
-	result := makeLLMFriendlyError(nil, "up")
+	result := MakeLLMFriendlyError(nil, "up")
 	if result != nil {
 		t.Errorf("expected nil error for nil input, got: %v", result)
 	}
@@ -135,9 +105,9 @@ func TestCheckEmptyResult(t *testing.T) {
 			expectedSubstr: []string{
 				"nonexistent_metric",
 				"returned no data",
-				"metric does not exist",
-				"no data for the specified time range",
-				"list_metrics",
+				"metric and labels you specified exist",
+				"no time series match",
+				"label filter combination",
 			},
 		},
 		{
@@ -148,7 +118,8 @@ func TestCheckEmptyResult(t *testing.T) {
 			expectedSubstr: []string{
 				"up{job=\"missing\"}",
 				"returned no data",
-				"label filters are too restrictive",
+				"label filter combination",
+				"label filters is too restrictive",
 			},
 		},
 		{


### PR DESCRIPTION
This commit transforms query errors to be LLM-friendly with guidance on how to proceed, and also detects and adds guidance for LLMs on empty query responses.