### PR TITLE
use Prometheus instead of Thanos by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The easiest way to get the obs-mcp connected to the cluster is via a kubeconfig:
  go run ./cmd/obs-mcp/ --listen 127.0.0.1:9100 --auth-mode kubeconfig --insecure
  ```
 
-This will connect the obs-mcp to the thanos querier running in the cluster.
+This will connect the obs-mcp to the Prometheus running in the cluster.
 
 This procedure would not work if you're not using token-based auth (`oc whoami -t` to validate).
 In that case, consider using serviceaccount + token auth. Alternatively, follow the procedure bellow.
@@ -36,10 +36,10 @@ This scenario opens a local port via port-forward that the obs-mcp will connect 
 
  1. Log into your OpenShift cluster
 
- 1. Port forward the OpenShift Thanos instance to a local port
+ 1. Port forward the OpenShift in-cluster Prometheus instance to a local port
 
 ``` sh
-PROM_POD=$(kubectl get pods -n openshift-monitoring -l app.kubernetes.io/instance=thanos-querier -o jsonpath="{.items[0].met
+PROM_POD=$(kubectl get pods -n openshift-monitoring -l app.kubernetes.io/instance=k8s -l app.kubernetes.io/component=prometheus -o jsonpath="{.items[0].met
 adata.name}")
 kubectl port-forward -n openshift-monitoring $PROM_POD 9090:9090
 ```

--- a/cmd/obs-mcp/main.go
+++ b/cmd/obs-mcp/main.go
@@ -102,7 +102,7 @@ func determinePrometheusURL(authMode mcp.AuthMode) string {
 	if authMode == mcp.AuthModeKubeConfig {
 		slog.Info("No Prometheus URL provided, attempting to use kubeconfig to discover Thanos Querier")
 
-		url, err := k8s.GetThanosQuerierURL()
+		url, err := k8s.GetPrometheusURL()
 		if err != nil {
 			slog.Warn("Failed to discover Thanos Querier via kubeconfig, falling back to localhost", "err", err)
 			return defaultPrometheusURL

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -11,10 +11,10 @@ import (
 )
 
 const (
-	openShiftRouteAPI      = "/apis/route.openshift.io/v1"
-	monitoringNamespace    = "openshift-monitoring"
-	routesResource         = "routes"
-	thanosQuerierRouteName = "thanos-querier"
+	openShiftRouteAPI   = "/apis/route.openshift.io/v1"
+	monitoringNamespace = "openshift-monitoring"
+	routesResource      = "routes"
+	prometheusRouteName = "prometheus-k8s"
 )
 
 // GetClientConfig returns a Kubernetes REST config using kubeconfig
@@ -47,8 +47,8 @@ func GetKubeClient() (*kubernetes.Clientset, error) {
 	return clientset, nil
 }
 
-// GetThanosQuerierURL discovers the Thanos Querier service URL in OpenShift
-func GetThanosQuerierURL() (string, error) {
+// GetPrometheusURL discovers the prometheus to be used in OpenShift environemtn.
+func GetPrometheusURL() (string, error) {
 	ctx := context.Background()
 
 	kubeClient, err := GetKubeClient()
@@ -61,11 +61,11 @@ func GetThanosQuerierURL() (string, error) {
 		AbsPath(openShiftRouteAPI).
 		Namespace(monitoringNamespace).
 		Resource(routesResource).
-		Name(thanosQuerierRouteName).
+		Name(prometheusRouteName).
 		Do(ctx)
 
 	if result.Error() != nil {
-		return "", fmt.Errorf("failed to load thanos-querier route: %w", result.Error())
+		return "", fmt.Errorf("failed to load prometheus route: %w", result.Error())
 	}
 
 	body, err := result.Raw()
@@ -86,5 +86,5 @@ func GetThanosQuerierURL() (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("no suitable route found for thanos-querier")
+	return "", fmt.Errorf("no suitable route found for prometheus")
 }


### PR DESCRIPTION
Thanos Querier doesn't seem to support TSDB endpoint, leading to

```
Query execution error: query validation failed: failed to retrieve metrics
information from Prometheus TSDB. Error details: client_error: client error:
404. Please verify that the Prometheus server is accessible and responding
correctly
```

Switching to prometheus for local development seems to be safer choice, at least
for now.
