### PR TITLE
Validate existence of metrics before query fires

### DIFF
--- a/pkg/prometheus/guardrails_test.go
+++ b/pkg/prometheus/guardrails_test.go
@@ -318,7 +318,8 @@ func TestGuardrails_MaxLabelCardinality(t *testing.T) {
 
 // mockPrometheusAPI is a mock implementation of v1.API for testing
 type mockPrometheusAPI struct {
-	tsdbResult v1.TSDBResult
+	tsdbResult       v1.TSDBResult
+	availableMetrics []string
 }
 
 func (m *mockPrometheusAPI) TSDB(ctx context.Context, opts ...v1.Option) (v1.TSDBResult, error) {
@@ -346,6 +347,14 @@ func (m *mockPrometheusAPI) LabelNames(ctx context.Context, matches []string, st
 	return nil, nil, nil
 }
 func (m *mockPrometheusAPI) LabelValues(ctx context.Context, label string, matches []string, startTime, endTime time.Time, opts ...v1.Option) (model.LabelValues, v1.Warnings, error) {
+	// Only handle __name__ label for metric listing
+	if label == "__name__" && m.availableMetrics != nil {
+		result := make(model.LabelValues, len(m.availableMetrics))
+		for i, metric := range m.availableMetrics {
+			result[i] = model.LabelValue(metric)
+		}
+		return result, nil, nil
+	}
 	return nil, nil, nil
 }
 func (m *mockPrometheusAPI) Query(ctx context.Context, query string, ts time.Time, opts ...v1.Option) (model.Value, v1.Warnings, error) {

--- a/pkg/prometheus/loader_test.go
+++ b/pkg/prometheus/loader_test.go
@@ -1,0 +1,93 @@
+package prometheus
+
+import (
+	"context"
+	"testing"
+)
+
+func TestValidateMetricsExist(t *testing.T) {
+	t.Run("Metric exists in Prometheus", func(t *testing.T) {
+		mock := &mockPrometheusAPI{
+			availableMetrics: []string{"http_requests_total", "node_cpu_seconds_total", "up"},
+		}
+		loader := &RealLoader{client: mock}
+
+		err := loader.ValidateMetricsExist(context.TODO(), `http_requests_total{job="api"}`)
+		if err != nil {
+			t.Errorf("expected no error when metric exists, got: %v", err)
+		}
+	})
+
+	t.Run("Metric does not exist in Prometheus", func(t *testing.T) {
+		mock := &mockPrometheusAPI{
+			availableMetrics: []string{"http_requests_total", "node_cpu_seconds_total", "up"},
+		}
+		loader := &RealLoader{client: mock}
+
+		err := loader.ValidateMetricsExist(context.TODO(), `nonexistent_metric{job="api"}`)
+		if err == nil {
+			t.Error("expected error when metric does not exist")
+		}
+	})
+
+	t.Run("Multiple metrics all exist", func(t *testing.T) {
+		mock := &mockPrometheusAPI{
+			availableMetrics: []string{"http_requests_total", "node_cpu_seconds_total", "up"},
+		}
+		loader := &RealLoader{client: mock}
+
+		err := loader.ValidateMetricsExist(context.TODO(), `http_requests_total{job="api"} + node_cpu_seconds_total{mode="idle"}`)
+		if err != nil {
+			t.Errorf("expected no error when all metrics exist, got: %v", err)
+		}
+	})
+
+	t.Run("Multiple metrics - one does not exist", func(t *testing.T) {
+		mock := &mockPrometheusAPI{
+			availableMetrics: []string{"http_requests_total", "node_cpu_seconds_total", "up"},
+		}
+		loader := &RealLoader{client: mock}
+
+		err := loader.ValidateMetricsExist(context.TODO(), `http_requests_total{job="api"} + nonexistent_metric{mode="idle"}`)
+		if err == nil {
+			t.Error("expected error when one metric does not exist")
+		}
+	})
+
+	t.Run("Metric with __name__ label matcher", func(t *testing.T) {
+		mock := &mockPrometheusAPI{
+			availableMetrics: []string{"http_requests_total", "node_cpu_seconds_total", "up"},
+		}
+		loader := &RealLoader{client: mock}
+
+		err := loader.ValidateMetricsExist(context.TODO(), `{__name__="http_requests_total", job="api"}`)
+		if err != nil {
+			t.Errorf("expected no error when metric exists via __name__ label, got: %v", err)
+		}
+	})
+
+	t.Run("Complex query with aggregations", func(t *testing.T) {
+		mock := &mockPrometheusAPI{
+			availableMetrics: []string{"http_requests_total", "node_cpu_seconds_total", "up"},
+		}
+		loader := &RealLoader{client: mock}
+
+		err := loader.ValidateMetricsExist(context.TODO(), `sum by (job) (rate(http_requests_total{job="api"}[5m]))`)
+		if err != nil {
+			t.Errorf("expected no error for complex query when metric exists, got: %v", err)
+		}
+	})
+
+	t.Run("Query with no metrics", func(t *testing.T) {
+		mock := &mockPrometheusAPI{
+			availableMetrics: []string{"http_requests_total"},
+		}
+		loader := &RealLoader{client: mock}
+
+		// A scalar value query - no metrics to validate
+		err := loader.ValidateMetricsExist(context.TODO(), `1 + 1`)
+		if err != nil {
+			t.Errorf("expected no error for query with no metrics, got: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
This commit adds an always on validator which uses ListMetrics to check that the metrics used in generated query exist.
(Ideally we move to #6 later, but for now this will suffice!