### PR TITLE
feat: add `--metrics-backend` flag for route discovery control

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,175 @@
 # obs mcp server
 
-This is an [mcp](https://modelcontextprotocol.io/introduction) server to allow LLMs to interact with a running [Prometheus](https://prometheus.io/) instance via the API.
+[![lint](https://github.com/rhobs/obs-mcp/actions/workflows/lint.yaml/badge.svg)](https://github.com/rhobs/obs-mcp/actions/workflows/lint.yaml)
+[![unit](https://github.com/rhobs/obs-mcp/actions/workflows/unit.yaml/badge.svg)](https://github.com/rhobs/obs-mcp/actions/workflows/unit.yaml)
+[![e2e](https://github.com/rhobs/obs-mcp/actions/workflows/e2e.yaml/badge.svg)](https://github.com/rhobs/obs-mcp/actions/workflows/e2e.yaml)
+
+obs-mcp is a [mcp](https://modelcontextprotocol.io/introduction) server to allow LLMs to interact with [Prometheus](https://prometheus.io/) or [Thanos Querier](https://thanos.io/) instances via the API.
 
 > [!NOTE]
 > This project is moved from [jhadvig/genie-plugin](https://github.com/jhadvig/genie-plugin/tree/main/obs-mcp) preserving the history of commits.
 
-## Development Quickstart
+## Quickstart
+
+### 1. Using Kubeconfig (OpenShift)
 
 The easiest way to get the obs-mcp connected to the cluster is via a kubeconfig:
 
- 1. Log into your OpenShift cluster
+ 1. Login into your OpenShift cluster
  2. Run the server with
 
- ```sh
+ ```shell
  go run ./cmd/obs-mcp/ --listen 127.0.0.1:9100 --auth-mode kubeconfig --insecure
  ```
 
-This will connect the obs-mcp to the Prometheus running in the cluster.
+This will auto-discover the metrics backend in OpenShift. By default, it tries `thanos-querier` route first, then falls back to `prometheus-k8s` route. Use `--metrics-backend` to control which route is preferred.
 
-This procedure would not work if you're not using token-based auth (`oc whoami -t` to validate).
-In that case, consider using serviceaccount + token auth. Alternatively, follow the procedure bellow.
+Use the `--metrics-backend` flag to specify which metrics backend to discover:
 
-> [!NOTE]
-> It is possible to hit the ground running locally as well:
+| Flag Value           | Behavior                                                              |
+|----------------------|-----------------------------------------------------------------------|
+| `thanos` (default)   | Tries `thanos-querier` route first, falls back to `prometheus-k8s`    |
+| `prometheus`         | Uses `prometheus-k8s` route only (no fallback)                        |
+
+> [!WARNING]
+> This procedure would not work if you're not using token-based auth (`oc > whoami -t` to validate).
+> In that case, consider using serviceaccount + token auth.
+
+**Example using Prometheus as the preferred backend:**
 
 ```shell
-helm install prometheus-community/prometheus --name-template <prefix> # sets up Prometheus (and exporters) on your local single-node k8s cluster
-export POD_NAME=$(kubectl get pods --namespace default -l "app.kubernetes.io/name=alertmanager,app.kubernetes.io/instance=local" -o jsonpath="{.items[0].metadata.name}") && kubectl --namespace default port-forward $POD_NAME 9090
-go run ./cmd/obs-mcp/ --auth-mode header --insecure --listen :9100 
+go run ./cmd/obs-mcp/ --listen 127.0.0.1:9100 --auth-mode kubeconfig --metrics-backend prometheus --insecure
 ```
 
-### Port-forwarding alternative
+**Example using Thanos as the preferred backend:**
+
+> [!NOTE]
+>
+> Thanos in OpenShift doesn't expose the TSDB endpoint, so guardrails that rely on TSDB stats won't work. Use `--guardrails=none` when using Thanos.
+
+```shell
+go run ./cmd/obs-mcp/ --listen 127.0.0.1:9100 --auth-mode kubeconfig --metrics-backend thanos --insecure --guardrails=none
+```
+
+> [!IMPORTANT]
+> **How the Metrics Backend URL is Determined:**
+>
+> 1. `PROMETHEUS_URL` environment variable (if set, always used)
+> 2. `--metrics-backend` flag route discovery (only in `kubeconfig` mode)
+> 3. Default: `http://localhost:9090`
+>
+>
+> **Example using explicit PROMETHEUS_URL:**
+>
+  ```shell
+  export PROMETHEUS_URL=https://thanos-querier.openshift-monitoring.svc.cluster.local:9091/
+  go run ./cmd/obs-mcp/ --listen 127.0.0.1:9100 --auth-mode kubeconfig --insecure
+  ```
+
+### 2. Port-forwarding alternative
 
 This scenario opens a local port via port-forward that the obs-mcp will connect to:
 
  1. Log into your OpenShift cluster
 
- 1. Port forward the OpenShift in-cluster Prometheus instance to a local port
+ 2. Port forward the OpenShift in-cluster Prometheus instance to a local port
 
-``` sh
-PROM_POD=$(kubectl get pods -n openshift-monitoring -l app.kubernetes.io/instance=k8s -l app.kubernetes.io/component=prometheus -o jsonpath="{.items[0].met
-adata.name}")
-kubectl port-forward -n openshift-monitoring $PROM_POD 9090:9090
+  ```shell
+  PROM_POD=$(kubectl get pods -n openshift-monitoring -l app.kubernetes.io/instance=k8s -l app.kubernetes.io/component=prometheus -o jsonpath="{.items[0].metadata.name}")
+
+  kubectl port-forward -n openshift-monitoring $PROM_POD 9090:9090
+  ```
+
+  Run the server with:
+
+  ```shell
+  export PROMETHEUS_URL=http://localhost:9090
+  go run ./cmd/obs-mcp/ --listen 127.0.0.1:9100 --auth-mode header
+  ```
+
+### 3. Local Development with Kind (using E2E test infrastructure)
+
+Use the E2E test infrastructure for a fully working local environment with Prometheus:
+
+#### Setup Kind cluster with Prometheus
+
+```bash
+make test-e2e-setup
 ```
 
- 1. Run the server with
+This creates a Kind cluster with:
 
-```sh
-PROMETHEUS_URL=http://localhost:9090 go run ./cmd/obs-mcp/ --listen 127.0.0.1:9100 --auth-mode header
+- Prometheus Operator
+- Prometheus (accessible at `prometheus-k8s.monitoring.svc.cluster.local:9090`)
+- Alertmanager
+
+#### Build and deploy obs-mcp
+
+```bash
+make test-e2e-deploy
 ```
+
+#### Port forward obs-mcp
+
+```bash
+kubectl port-forward -n obs-mcp svc/obs-mcp 9100:9100
+```
+
+To connect an MCP client, use `http://localhost:9100/mcp`.
+
+When done:
+
+```bash
+make test-e2e-teardown
+```
+
+See [TESTING.md](TESTING.md) for more details.
+
+### 4. Using prometheus helm chart in local Kubernetes cluster
+
+```shell
+# sets up Prometheus (and exporters) on your local single-node k8s cluster
+helm install prometheus-community/prometheus --name-template <prefix>
+
+export POD_NAME=$(kubectl get pods --namespace default -l "app.kubernetes.io/name=alertmanager,app.kubernetes.io/instance=local" -o jsonpath="{.items[0].metadata.name}") && kubectl --namespace default port-forward $POD_NAME 9090
+
+go run ./cmd/obs-mcp/ --auth-mode header --insecure --listen :9100 
+```
+
+### Testing with curl
+
+You can test the MCP server using curl. The server uses `JSON-RPC 2.0` over `HTTP`.
+
+> [!TIP]
+> For formatted JSON output, pipe the response to `jq`:
+>
+> curl ... | jq
+>
+
+**List available tools:**
+
+```shell
+curl -X POST http://localhost:9100/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'|jq
+```
+
+**Call the list_metrics tool:**
+
+```shell
+curl -X POST http://localhost:9100/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_metrics","arguments":{}}}' | jq
+```
+  
+**Execute a range query (e.g., get up metrics for the last hour):**
+
+```shell
+curl -X POST http://localhost:9100/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"execute_range_query","arguments":{"query":"up{job=\"prometheus\"}","step":"1m","end":"NOW","duration":"1h"}}}' | jq
+```
+
+## License
+
+[Apache 2.0](LICENSE)

--- a/cmd/obs-mcp/main.go
+++ b/cmd/obs-mcp/main.go
@@ -3,9 +3,11 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"log/slog"
 	"os"
+	"strings"
 
 	"github.com/prometheus/common/promslog"
 
@@ -26,7 +28,7 @@ func main() {
 	var authMode = flag.String("auth-mode", "", "Authentication mode: kubeconfig, serviceaccount, or header")
 	var insecure = flag.Bool("insecure", false, "Skip TLS certificate verification")
 	var logLevel = flag.String("log-level", "info", "Log level: debug, info, warn, error")
-
+	var metricsBackend = flag.String("metrics-backend", "thanos", "Metrics backend: thanos (default, with prometheus fallback) or prometheus (strict, no fallback)")
 	var guardrails = flag.String("guardrails", "all", "Guardrails configuration: 'all' (default), 'none', or comma-separated list of guardrails to enable (disallow-explicit-name-label, require-label-matcher, disallow-blanket-regex)")
 	var maxMetricCardinality = flag.Uint64("guardrails.max-metric-cardinality", 20000, "Maximum allowed series count per metric (0 = disabled)")
 	var maxLabelCardinality = flag.Uint64("guardrails.max-label-cardinality", 500, "Maximum allowed label value count for blanket regex (0 = always disallow blanket regex). Only takes effect if disallow-blanket-regex is enabled.")
@@ -41,8 +43,14 @@ func main() {
 		log.Fatalf("Invalid auth mode: %v", err)
 	}
 
-	// Determine Prometheus URL
-	promURL := determinePrometheusURL(parsedAuthMode)
+	// Parse and validate metrics backend
+	parsedMetricsBackend, err := parseMetricsBackend(*metricsBackend)
+	if err != nil {
+		log.Fatalf("Invalid metrics backend: %v", err)
+	}
+
+	// Determine metrics backend URL - pass the backend type
+	metricsBackendURL := determineMetricsBackendURL(parsedAuthMode, parsedMetricsBackend)
 
 	// Parse guardrails configuration
 	parsedGuardrails, err := prometheus.ParseGuardrails(*guardrails)
@@ -58,10 +66,10 @@ func main() {
 
 	// Create MCP options
 	opts := mcp.ObsMCPOptions{
-		AuthMode:   parsedAuthMode,
-		PromURL:    promURL,
-		Insecure:   *insecure,
-		Guardrails: parsedGuardrails,
+		AuthMode:          parsedAuthMode,
+		MetricsBackendURL: metricsBackendURL,
+		Insecure:          *insecure,
+		Guardrails:        parsedGuardrails,
 	}
 
 	// Create MCP server
@@ -70,7 +78,7 @@ func main() {
 		log.Fatalf("Failed to create MCP server: %v", err)
 	}
 
-	slog.Info("Starting server", "PromURL", opts.PromURL, "AuthMode", opts.AuthMode)
+	slog.Info("Starting server", "MetricsBackendURL", opts.MetricsBackendURL, "AuthMode", opts.AuthMode, "Guardrails", opts.Guardrails)
 
 	// Choose server mode based on flags
 	if *listen != "" {
@@ -88,27 +96,38 @@ func main() {
 	}
 }
 
-// determinePrometheusURL determines the Prometheus URL based on auth mode and environment
-func determinePrometheusURL(authMode mcp.AuthMode) string {
-	// Get Prometheus URL from environment variable
-	promURL := os.Getenv("PROMETHEUS_URL")
+func parseMetricsBackend(backend string) (k8s.MetricsBackend, error) {
+	switch strings.ToLower(backend) {
+	case "thanos", "":
+		return k8s.MetricsBackendThanos, nil
+	case "prometheus":
+		return k8s.MetricsBackendPrometheus, nil
+	default:
+		return "", fmt.Errorf("unknown metrics backend %q, must be 'thanos' or 'prometheus'", backend)
+	}
+}
+
+// determineMetricsBackendURL determines the metrics backend URL based on auth mode and environment.
+func determineMetricsBackendURL(authMode mcp.AuthMode, backend k8s.MetricsBackend) string {
+	// Get metrics backend URL from environment variable PROMETHEUS_URL
+	prometheusURL := os.Getenv("PROMETHEUS_URL")
 
 	// If URL is provided, use it
-	if promURL != "" {
-		return promURL
+	if prometheusURL != "" {
+		return prometheusURL
 	}
 
-	// For kubeconfig mode, attempt to discover Thanos Querier
+	// For kubeconfig mode, attempt to discover route based on selected backend
 	if authMode == mcp.AuthModeKubeConfig {
-		slog.Info("No Prometheus URL provided, attempting to use kubeconfig to discover Thanos Querier")
+		slog.Info("No metrics backend URL provided, attempting to discover via kubeconfig", "backend", backend)
 
-		url, err := k8s.GetPrometheusURL()
+		url, err := k8s.GetMetricsBackendURL(backend)
 		if err != nil {
-			slog.Warn("Failed to discover Thanos Querier via kubeconfig, falling back to localhost", "err", err)
+			slog.Warn("Failed to discover metrics backend via kubeconfig", "err", err, "fallback_url", defaultPrometheusURL)
 			return defaultPrometheusURL
 		}
 
-		slog.Info("Discovered Thanos Querier URL", "url", url)
+		slog.Info("Discovered metrics backend URL", "url", url)
 		return url
 	}
 

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -1,0 +1,63 @@
+package k8s
+
+import (
+	"testing"
+)
+
+func TestGetRouteURLParseHost(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		wantHost string
+		wantErr  bool
+	}{
+		{
+			name:     "valid route with host",
+			body:     `{"kind":"Route","spec":{"host":"thanos-querier.apps.example.com"}}`,
+			wantHost: "https://thanos-querier.apps.example.com",
+			wantErr:  false,
+		},
+		{
+			name:     "route without host field",
+			body:     `{"kind":"Route","spec":{}}`,
+			wantHost: "",
+			wantErr:  true,
+		},
+		{
+			name:     "empty body",
+			body:     `{}`,
+			wantHost: "",
+			wantErr:  true,
+		},
+		{
+			name:     "host with port in URL",
+			body:     `{"spec":{"host":"thanos-querier.apps.example.com:9091"}}`,
+			wantHost: "https://thanos-querier.apps.example.com:9091",
+			wantErr:  false,
+		},
+		{
+			name:     "empty host value",
+			body:     `{"spec":{"host":""}}`,
+			wantHost: "",
+			wantErr:  true,
+		},
+		{
+			name:     "malformed JSON with host-like string",
+			body:     `not json but has "host": in it`,
+			wantHost: "",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			host := parseHostFromRouteBody(tt.body)
+			if tt.wantErr && host != "" {
+				t.Errorf("expected empty host, got %s", host)
+			}
+			if !tt.wantErr && host != tt.wantHost {
+				t.Errorf("expected host %s, got %s", tt.wantHost, host)
+			}
+		})
+	}
+}

--- a/pkg/mcp/auth.go
+++ b/pkg/mcp/auth.go
@@ -118,7 +118,7 @@ func createKubeconfigAPIConfig(opts ObsMCPOptions) (promapi.Config, error) {
 	}
 
 	return promapi.Config{
-		Address:      opts.PromURL,
+		Address:      opts.MetricsBackendURL,
 		RoundTripper: rt,
 	}, nil
 }
@@ -132,7 +132,7 @@ func createServiceAccountAPIConfig(opts ObsMCPOptions) (promapi.Config, error) {
 	}
 	token := string(tokenBytes)
 
-	return createAPIConfigWithToken(opts.PromURL, token, opts.Insecure)
+	return createAPIConfigWithToken(opts.MetricsBackendURL, token, opts.Insecure)
 }
 
 func createHeaderAPIConfig(ctx context.Context, opts ObsMCPOptions) (promapi.Config, error) {
@@ -141,7 +141,7 @@ func createHeaderAPIConfig(ctx context.Context, opts ObsMCPOptions) (promapi.Con
 		slog.Warn("No token provided in context for header auth mode")
 	}
 
-	return createAPIConfigWithToken(opts.PromURL, token, opts.Insecure)
+	return createAPIConfigWithToken(opts.MetricsBackendURL, token, opts.Insecure)
 }
 
 func createAPIConfigWithToken(prometheusURL, token string, insecure bool) (promapi.Config, error) {

--- a/pkg/mcp/auth_test.go
+++ b/pkg/mcp/auth_test.go
@@ -47,8 +47,8 @@ func TestCreateHeaderAPIConfig(t *testing.T) {
 
 	// Step 4: Create API config using the complete production code path
 	opts := ObsMCPOptions{
-		PromURL:  "https://prometheus.example.com",
-		Insecure: true,
+		MetricsBackendURL: "https://prometheus.example.com",
+		Insecure:          true,
 	}
 	apiConfig, err := createHeaderAPIConfig(ctx, opts)
 	if err != nil {

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -18,10 +18,10 @@ import (
 
 // ObsMCPOptions contains configuration options for the MCP server
 type ObsMCPOptions struct {
-	AuthMode   AuthMode
-	PromURL    string
-	Insecure   bool
-	Guardrails *prometheus.Guardrails
+	AuthMode          AuthMode
+	MetricsBackendURL string
+	Insecure          bool
+	Guardrails        *prometheus.Guardrails
 }
 
 const (


### PR DESCRIPTION
Refactor metrics backend discovery to try thanos-querier route first, then fall back to prometheus-k8s route.
updated README with auto-discovery behavior and curl examples