### PR TITLE
toolset: Rename toolset to observability

### DIFF
--- a/pkg/toolset/toolset.go
+++ b/pkg/toolset/toolset.go
@@ -16,7 +16,7 @@ var _ api.Toolset = (*Toolset)(nil)
 
 // GetName returns the name of the toolset.
 func (t *Toolset) GetName() string {
-	return "obs-mcp"
+	return "metrics"
 }
 
 // GetDescription returns a human-readable description of the toolset.


### PR DESCRIPTION
As per conventions in openshift-mcp-server, we need to rename the toolset to something more suitable as per
https://github.com/openshift/openshift-mcp-server/pull/226#issuecomment-4259289448