### PR TITLE
fix guardrails cardinality limit settings

### DIFF
--- a/cmd/obs-mcp/main.go
+++ b/cmd/obs-mcp/main.go
@@ -86,9 +86,7 @@ func main() {
 		log.Fatalf("Invalid guardrails configuration: %v", err)
 	}
 
-	applyCardinalityLimits(parsedGuardrails, *guardrails, *maxMetricCardinality, *maxLabelCardinality,
-		isFlagExplicitlySet("guardrails.max-metric-cardinality"),
-		isFlagExplicitlySet("guardrails.max-label-cardinality"))
+	applyCardinalityLimits(parsedGuardrails, *guardrails, *maxMetricCardinality, *maxLabelCardinality)
 
 	// Create MCP options
 	opts := mcpserver.ObsMCPOptions{
@@ -135,15 +133,17 @@ func main() {
 // guardrails struct. When all guardrails are enabled (guardrailsFlag is "all" or ""),
 // the flag defaults are applied. For explicit subsets, cardinality limits are only
 // applied if the user explicitly passed the corresponding flag.
-func applyCardinalityLimits(g *prometheus.Guardrails, guardrailsFlag string, maxMetricCard, maxLabelCard uint64, metricCardExplicit, labelCardExplicit bool) {
+func applyCardinalityLimits(g *prometheus.Guardrails, guardrailsFlag string, maxMetricCard, maxLabelCard uint64) {
 	if g == nil {
 		return
 	}
 	allGuardrails := guardrailsFlag == "all" || guardrailsFlag == ""
-	if allGuardrails || metricCardExplicit {
+
+	if allGuardrails || strings.Contains(guardrailsFlag, prometheus.GuardrailMaxMetricCardinality) {
 		g.MaxMetricCardinality = maxMetricCard
 	}
-	if allGuardrails || labelCardExplicit {
+
+	if allGuardrails || strings.Contains(guardrailsFlag, prometheus.GuardrailMaxLabelCardinality) {
 		g.MaxLabelCardinality = maxLabelCard
 	}
 }

--- a/cmd/obs-mcp/main.go
+++ b/cmd/obs-mcp/main.go
@@ -86,11 +86,9 @@ func main() {
 		log.Fatalf("Invalid guardrails configuration: %v", err)
 	}
 
-	// Set max metric cardinality and max label cardinality if guardrails are enabled
-	if parsedGuardrails != nil {
-		parsedGuardrails.MaxMetricCardinality = *maxMetricCardinality
-		parsedGuardrails.MaxLabelCardinality = *maxLabelCardinality
-	}
+	applyCardinalityLimits(parsedGuardrails, *guardrails, *maxMetricCardinality, *maxLabelCardinality,
+		isFlagExplicitlySet("guardrails.max-metric-cardinality"),
+		isFlagExplicitlySet("guardrails.max-label-cardinality"))
 
 	// Create MCP options
 	opts := mcpserver.ObsMCPOptions{
@@ -130,6 +128,23 @@ func main() {
 		if _, err := mcpServer.Connect(context.Background(), transport, nil); err != nil {
 			log.Fatalf("Server failed: %v", err)
 		}
+	}
+}
+
+// applyCardinalityLimits sets MaxMetricCardinality and MaxLabelCardinality on the
+// guardrails struct. When all guardrails are enabled (guardrailsFlag is "all" or ""),
+// the flag defaults are applied. For explicit subsets, cardinality limits are only
+// applied if the user explicitly passed the corresponding flag.
+func applyCardinalityLimits(g *prometheus.Guardrails, guardrailsFlag string, maxMetricCard, maxLabelCard uint64, metricCardExplicit, labelCardExplicit bool) {
+	if g == nil {
+		return
+	}
+	allGuardrails := guardrailsFlag == "all" || guardrailsFlag == ""
+	if allGuardrails || metricCardExplicit {
+		g.MaxMetricCardinality = maxMetricCard
+	}
+	if allGuardrails || labelCardExplicit {
+		g.MaxLabelCardinality = maxLabelCard
 	}
 }
 

--- a/cmd/obs-mcp/main_test.go
+++ b/cmd/obs-mcp/main_test.go
@@ -14,8 +14,6 @@ func TestApplyCardinalityLimits(t *testing.T) {
 		guardrailsFlag           string
 		maxMetricCard            uint64
 		maxLabelCard             uint64
-		metricCardExplicit       bool
-		labelCardExplicit        bool
 		wantMaxMetricCardinality uint64
 		wantMaxLabelCardinality  uint64
 	}{
@@ -44,21 +42,25 @@ func TestApplyCardinalityLimits(t *testing.T) {
 			wantMaxLabelCardinality:  0,
 		},
 		{
-			name:                     "explicit subset with explicit max-metric-cardinality flag",
-			guardrailsFlag:           "require-label-matcher",
+			name:                     "explicit subset with max-metric-cardinality in guardrails flag",
+			guardrailsFlag:           "require-label-matcher,max-metric-cardinality",
 			maxMetricCard:            10000,
 			maxLabelCard:             500,
-			metricCardExplicit:       true,
 			wantMaxMetricCardinality: 10000,
 			wantMaxLabelCardinality:  0,
 		},
 		{
-			name:                     "explicit subset with both cardinality flags explicit",
-			guardrailsFlag:           "disallow-blanket-regex",
+			name:                     "explicit subset with max-metric-cardinality flag using default value",
+			guardrailsFlag:           "max-metric-cardinality",
+			maxMetricCard:            20000,
+			wantMaxMetricCardinality: 20000,
+			wantMaxLabelCardinality:  0,
+		},
+		{
+			name:                     "explicit subset with both cardinality guardrails",
+			guardrailsFlag:           "disallow-blanket-regex,max-metric-cardinality,max-label-cardinality",
 			maxMetricCard:            15000,
 			maxLabelCard:             300,
-			metricCardExplicit:       true,
-			labelCardExplicit:        true,
 			wantMaxMetricCardinality: 15000,
 			wantMaxLabelCardinality:  300,
 		},
@@ -75,7 +77,7 @@ func TestApplyCardinalityLimits(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := &prometheus.Guardrails{}
-			applyCardinalityLimits(g, tt.guardrailsFlag, tt.maxMetricCard, tt.maxLabelCard, tt.metricCardExplicit, tt.labelCardExplicit)
+			applyCardinalityLimits(g, tt.guardrailsFlag, tt.maxMetricCard, tt.maxLabelCard)
 			if g.MaxMetricCardinality != tt.wantMaxMetricCardinality {
 				t.Errorf("MaxMetricCardinality = %v, want %v", g.MaxMetricCardinality, tt.wantMaxMetricCardinality)
 			}
@@ -87,7 +89,7 @@ func TestApplyCardinalityLimits(t *testing.T) {
 }
 
 func TestApplyCardinalityLimits_NilGuardrails(t *testing.T) {
-	applyCardinalityLimits(nil, "all", 20000, 500, false, false)
+	applyCardinalityLimits(nil, "all", 20000, 500)
 }
 
 // TestParseMetricsBackend verifies the --metrics-backend flag parsing logic

--- a/cmd/obs-mcp/main_test.go
+++ b/cmd/obs-mcp/main_test.go
@@ -5,7 +5,90 @@ import (
 
 	"github.com/rhobs/obs-mcp/pkg/k8s"
 	"github.com/rhobs/obs-mcp/pkg/mcp"
+	"github.com/rhobs/obs-mcp/pkg/prometheus"
 )
+
+func TestApplyCardinalityLimits(t *testing.T) {
+	tests := []struct {
+		name                     string
+		guardrailsFlag           string
+		maxMetricCard            uint64
+		maxLabelCard             uint64
+		metricCardExplicit       bool
+		labelCardExplicit        bool
+		wantMaxMetricCardinality uint64
+		wantMaxLabelCardinality  uint64
+	}{
+		{
+			name:                     "all guardrails applies defaults",
+			guardrailsFlag:           "all",
+			maxMetricCard:            20000,
+			maxLabelCard:             500,
+			wantMaxMetricCardinality: 20000,
+			wantMaxLabelCardinality:  500,
+		},
+		{
+			name:                     "empty guardrails flag applies defaults",
+			guardrailsFlag:           "",
+			maxMetricCard:            20000,
+			maxLabelCard:             500,
+			wantMaxMetricCardinality: 20000,
+			wantMaxLabelCardinality:  500,
+		},
+		{
+			name:                     "explicit subset without cardinality flags does not apply defaults",
+			guardrailsFlag:           "require-label-matcher,disallow-blanket-regex",
+			maxMetricCard:            20000,
+			maxLabelCard:             500,
+			wantMaxMetricCardinality: 0,
+			wantMaxLabelCardinality:  0,
+		},
+		{
+			name:                     "explicit subset with explicit max-metric-cardinality flag",
+			guardrailsFlag:           "require-label-matcher",
+			maxMetricCard:            10000,
+			maxLabelCard:             500,
+			metricCardExplicit:       true,
+			wantMaxMetricCardinality: 10000,
+			wantMaxLabelCardinality:  0,
+		},
+		{
+			name:                     "explicit subset with both cardinality flags explicit",
+			guardrailsFlag:           "disallow-blanket-regex",
+			maxMetricCard:            15000,
+			maxLabelCard:             300,
+			metricCardExplicit:       true,
+			labelCardExplicit:        true,
+			wantMaxMetricCardinality: 15000,
+			wantMaxLabelCardinality:  300,
+		},
+		{
+			name:                     "all guardrails with custom cardinality values",
+			guardrailsFlag:           "all",
+			maxMetricCard:            50000,
+			maxLabelCard:             1000,
+			wantMaxMetricCardinality: 50000,
+			wantMaxLabelCardinality:  1000,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &prometheus.Guardrails{}
+			applyCardinalityLimits(g, tt.guardrailsFlag, tt.maxMetricCard, tt.maxLabelCard, tt.metricCardExplicit, tt.labelCardExplicit)
+			if g.MaxMetricCardinality != tt.wantMaxMetricCardinality {
+				t.Errorf("MaxMetricCardinality = %v, want %v", g.MaxMetricCardinality, tt.wantMaxMetricCardinality)
+			}
+			if g.MaxLabelCardinality != tt.wantMaxLabelCardinality {
+				t.Errorf("MaxLabelCardinality = %v, want %v", g.MaxLabelCardinality, tt.wantMaxLabelCardinality)
+			}
+		})
+	}
+}
+
+func TestApplyCardinalityLimits_NilGuardrails(t *testing.T) {
+	applyCardinalityLimits(nil, "all", 20000, 500, false, false)
+}
 
 // TestParseMetricsBackend verifies the --metrics-backend flag parsing logic
 func TestParseMetricsBackend(t *testing.T) {

--- a/pkg/toolset/config/config.go
+++ b/pkg/toolset/config/config.go
@@ -55,13 +55,13 @@ type Config struct {
 	// MaxMetricCardinality is the maximum allowed series count per metric.
 	// Set to 0 to disable this check.
 	// Default: 20000
-	MaxMetricCardinality uint64 `toml:"max_metric_cardinality,omitempty"`
+	MaxMetricCardinality *uint64 `toml:"max_metric_cardinality,omitempty"`
 
 	// MaxLabelCardinality is the maximum allowed label value count for blanket regex.
 	// Only takes effect if disallow-blanket-regex is enabled.
 	// Set to 0 to always disallow blanket regex.
 	// Default: 500
-	MaxLabelCardinality uint64 `toml:"max_label_cardinality,omitempty"`
+	MaxLabelCardinality *uint64 `toml:"max_label_cardinality,omitempty"`
 
 	// RangeQueryFullResponse controls whether range queries return full data points
 	// instead of summary statistics.
@@ -111,17 +111,23 @@ func (c *Config) GetGuardrails() (*prometheus.Guardrails, error) {
 		allGuardrails := guardrailsStr == "all" || c.Guardrails == ""
 
 		if allGuardrails {
-			guardrails.MaxMetricCardinality = c.MaxMetricCardinality
-			if guardrails.MaxMetricCardinality == 0 {
-				guardrails.MaxMetricCardinality = 20000
+			if c.MaxMetricCardinality != nil {
+				guardrails.MaxMetricCardinality = *c.MaxMetricCardinality
+			} else {
+				guardrails.MaxMetricCardinality = prometheus.DefaultGuardrails().MaxMetricCardinality
 			}
-			guardrails.MaxLabelCardinality = c.MaxLabelCardinality
-			if guardrails.MaxLabelCardinality == 0 {
-				guardrails.MaxLabelCardinality = 500
+			if c.MaxLabelCardinality != nil {
+				guardrails.MaxLabelCardinality = *c.MaxLabelCardinality
+			} else {
+				guardrails.MaxLabelCardinality = prometheus.DefaultGuardrails().MaxLabelCardinality
 			}
 		} else {
-			guardrails.MaxMetricCardinality = c.MaxMetricCardinality
-			guardrails.MaxLabelCardinality = c.MaxLabelCardinality
+			if c.MaxMetricCardinality != nil {
+				guardrails.MaxMetricCardinality = *c.MaxMetricCardinality
+			}
+			if c.MaxLabelCardinality != nil {
+				guardrails.MaxLabelCardinality = *c.MaxLabelCardinality
+			}
 		}
 	}
 

--- a/pkg/toolset/config/config.go
+++ b/pkg/toolset/config/config.go
@@ -108,18 +108,21 @@ func (c *Config) GetGuardrails() (*prometheus.Guardrails, error) {
 	}
 
 	if guardrails != nil {
-		// Apply cardinality limits
-		maxMetricCard := c.MaxMetricCardinality
-		if maxMetricCard == 0 {
-			maxMetricCard = 20000 // default
-		}
-		guardrails.MaxMetricCardinality = maxMetricCard
+		allGuardrails := guardrailsStr == "all" || c.Guardrails == ""
 
-		maxLabelCard := c.MaxLabelCardinality
-		if maxLabelCard == 0 {
-			maxLabelCard = 500 // default
+		if allGuardrails {
+			guardrails.MaxMetricCardinality = c.MaxMetricCardinality
+			if guardrails.MaxMetricCardinality == 0 {
+				guardrails.MaxMetricCardinality = 20000
+			}
+			guardrails.MaxLabelCardinality = c.MaxLabelCardinality
+			if guardrails.MaxLabelCardinality == 0 {
+				guardrails.MaxLabelCardinality = 500
+			}
+		} else {
+			guardrails.MaxMetricCardinality = c.MaxMetricCardinality
+			guardrails.MaxLabelCardinality = c.MaxLabelCardinality
 		}
-		guardrails.MaxLabelCardinality = maxLabelCard
 	}
 
 	return guardrails, nil

--- a/pkg/toolset/config/config_test.go
+++ b/pkg/toolset/config/config_test.go
@@ -1,8 +1,15 @@
 package config
 
 import (
+	"context"
 	"testing"
+
+	"github.com/BurntSushi/toml"
+
+	"github.com/rhobs/obs-mcp/pkg/prometheus"
 )
+
+func uint64Ptr(v uint64) *uint64 { return &v }
 
 func TestGetGuardrails(t *testing.T) {
 	tests := []struct {
@@ -41,7 +48,7 @@ func TestGetGuardrails(t *testing.T) {
 		},
 		{
 			name:                     "explicit subset does not enable cardinality guardrails",
-			config:                   Config{Guardrails: "require-label-matcher,disallow-blanket-regex"},
+			config:                   Config{Guardrails: prometheus.GuardrailRequireLabelMatcher + "," + prometheus.GuardrailDisallowBlanketRegex},
 			wantRequireLabelMatcher:  true,
 			wantDisallowBlanketRegex: true,
 			wantMaxMetricCardinality: 0,
@@ -49,7 +56,7 @@ func TestGetGuardrails(t *testing.T) {
 		},
 		{
 			name:                     "explicit subset with user-specified cardinality limits",
-			config:                   Config{Guardrails: "require-label-matcher,disallow-blanket-regex", MaxMetricCardinality: 10000, MaxLabelCardinality: 200},
+			config:                   Config{Guardrails: prometheus.GuardrailRequireLabelMatcher + "," + prometheus.GuardrailDisallowBlanketRegex, MaxMetricCardinality: uint64Ptr(10000), MaxLabelCardinality: uint64Ptr(200)},
 			wantRequireLabelMatcher:  true,
 			wantDisallowBlanketRegex: true,
 			wantMaxMetricCardinality: 10000,
@@ -57,19 +64,28 @@ func TestGetGuardrails(t *testing.T) {
 		},
 		{
 			name:                     "single guardrail only enables that one",
-			config:                   Config{Guardrails: "require-label-matcher"},
+			config:                   Config{Guardrails: prometheus.GuardrailRequireLabelMatcher},
 			wantRequireLabelMatcher:  true,
 			wantMaxMetricCardinality: 0,
 			wantMaxLabelCardinality:  0,
 		},
 		{
 			name:                     "all with custom cardinality limits",
-			config:                   Config{Guardrails: "all", MaxMetricCardinality: 50000, MaxLabelCardinality: 1000},
+			config:                   Config{Guardrails: "all", MaxMetricCardinality: uint64Ptr(50000), MaxLabelCardinality: uint64Ptr(1000)},
 			wantDisallowExplicitName: true,
 			wantRequireLabelMatcher:  true,
 			wantDisallowBlanketRegex: true,
 			wantMaxMetricCardinality: 50000,
 			wantMaxLabelCardinality:  1000,
+		},
+		{
+			name:                     "all with disabling the cardinality limits",
+			config:                   Config{Guardrails: "all", MaxMetricCardinality: uint64Ptr(0), MaxLabelCardinality: uint64Ptr(0)},
+			wantDisallowExplicitName: true,
+			wantRequireLabelMatcher:  true,
+			wantDisallowBlanketRegex: true,
+			wantMaxMetricCardinality: 0,
+			wantMaxLabelCardinality:  0,
 		},
 		{
 			name:      "unknown guardrail returns error",
@@ -113,6 +129,110 @@ func TestGetGuardrails(t *testing.T) {
 			}
 			if g.MaxLabelCardinality != tt.wantMaxLabelCardinality {
 				t.Errorf("MaxLabelCardinality = %v, want %v", g.MaxLabelCardinality, tt.wantMaxLabelCardinality)
+			}
+		})
+	}
+}
+
+func TestObsMCPToolsetParser(t *testing.T) {
+	type wrapper struct {
+		Toolset toml.Primitive `toml:"toolset"`
+	}
+
+	tests := []struct {
+		name                     string
+		tomlInput                string
+		expectErr                bool
+		wantPrometheusURL        string
+		wantGuardrails           string
+		wantMaxMetricCardinality *uint64
+		wantMaxLabelCardinality  *uint64
+	}{
+		{
+			name:              "cardinality fields omitted leaves pointers nil",
+			tomlInput:         `[toolset]` + "\n" + `prometheus_url = "http://localhost:9090"`,
+			wantPrometheusURL: "http://localhost:9090",
+		},
+		{
+			name:                     "cardinality fields set to 0 produces non-nil pointers",
+			tomlInput:                `[toolset]` + "\n" + `prometheus_url = "http://localhost:9090"` + "\n" + `max_metric_cardinality = 0` + "\n" + `max_label_cardinality = 0`,
+			wantPrometheusURL:        "http://localhost:9090",
+			wantMaxMetricCardinality: uint64Ptr(0),
+			wantMaxLabelCardinality:  uint64Ptr(0),
+		},
+		{
+			name:                     "cardinality fields set to specific values",
+			tomlInput:                `[toolset]` + "\n" + `prometheus_url = "http://localhost:9090"` + "\n" + `max_metric_cardinality = 10000` + "\n" + `max_label_cardinality = 200`,
+			wantPrometheusURL:        "http://localhost:9090",
+			wantMaxMetricCardinality: uint64Ptr(10000),
+			wantMaxLabelCardinality:  uint64Ptr(200),
+		},
+		{
+			name:              "all config fields parsed",
+			tomlInput:         `[toolset]` + "\n" + `prometheus_url = "http://localhost:9090"` + "\n" + `guardrails = "` + prometheus.GuardrailRequireLabelMatcher + `"` + "\n" + `insecure = true`,
+			wantPrometheusURL: "http://localhost:9090",
+			wantGuardrails:    prometheus.GuardrailRequireLabelMatcher,
+		},
+		{
+			name: "full config with all guardrails and cardinality limits",
+			tomlInput: `[toolset]` + "\n" +
+				`prometheus_url = "http://localhost:9090"` + "\n" +
+				`alertmanager_url = "http://localhost:9093"` + "\n" +
+				`guardrails = "` + prometheus.GuardrailDisallowExplicitNameLabel + `,` + prometheus.GuardrailRequireLabelMatcher + `,` + prometheus.GuardrailDisallowBlanketRegex + `"`,
+			wantPrometheusURL: "http://localhost:9090",
+			wantGuardrails:    prometheus.GuardrailDisallowExplicitNameLabel + "," + prometheus.GuardrailRequireLabelMatcher + "," + prometheus.GuardrailDisallowBlanketRegex,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var w wrapper
+			md, err := toml.Decode(tt.tomlInput, &w)
+			if err != nil {
+				t.Fatalf("failed to decode TOML: %v", err)
+			}
+
+			cfg, err := obsMCPToolsetParser(context.Background(), w.Toolset, md)
+			if tt.expectErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			c := cfg.(*Config)
+			if c.PrometheusURL != tt.wantPrometheusURL {
+				t.Errorf("PrometheusURL = %q, want %q", c.PrometheusURL, tt.wantPrometheusURL)
+			}
+			if c.Guardrails != tt.wantGuardrails {
+				t.Errorf("Guardrails = %q, want %q", c.Guardrails, tt.wantGuardrails)
+			}
+			if tt.wantMaxMetricCardinality == nil {
+				if c.MaxMetricCardinality != nil {
+					t.Errorf("MaxMetricCardinality = %v, want nil", *c.MaxMetricCardinality)
+				}
+			} else {
+				if c.MaxMetricCardinality == nil {
+					t.Fatal("MaxMetricCardinality is nil, want non-nil")
+				}
+				if *c.MaxMetricCardinality != *tt.wantMaxMetricCardinality {
+					t.Errorf("MaxMetricCardinality = %d, want %d", *c.MaxMetricCardinality, *tt.wantMaxMetricCardinality)
+				}
+			}
+			if tt.wantMaxLabelCardinality == nil {
+				if c.MaxLabelCardinality != nil {
+					t.Errorf("MaxLabelCardinality = %v, want nil", *c.MaxLabelCardinality)
+				}
+			} else {
+				if c.MaxLabelCardinality == nil {
+					t.Fatal("MaxLabelCardinality is nil, want non-nil")
+				}
+				if *c.MaxLabelCardinality != *tt.wantMaxLabelCardinality {
+					t.Errorf("MaxLabelCardinality = %d, want %d", *c.MaxLabelCardinality, *tt.wantMaxLabelCardinality)
+				}
 			}
 		})
 	}

--- a/pkg/toolset/config/config_test.go
+++ b/pkg/toolset/config/config_test.go
@@ -1,0 +1,119 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestGetGuardrails(t *testing.T) {
+	tests := []struct {
+		name                     string
+		config                   Config
+		expectNil                bool
+		expectErr                bool
+		wantDisallowExplicitName bool
+		wantRequireLabelMatcher  bool
+		wantDisallowBlanketRegex bool
+		wantMaxMetricCardinality uint64
+		wantMaxLabelCardinality  uint64
+	}{
+		{
+			name:                     "default (empty) enables all guardrails with default cardinality",
+			config:                   Config{},
+			wantDisallowExplicitName: true,
+			wantRequireLabelMatcher:  true,
+			wantDisallowBlanketRegex: true,
+			wantMaxMetricCardinality: 20000,
+			wantMaxLabelCardinality:  500,
+		},
+		{
+			name:                     "all enables all guardrails with default cardinality",
+			config:                   Config{Guardrails: "all"},
+			wantDisallowExplicitName: true,
+			wantRequireLabelMatcher:  true,
+			wantDisallowBlanketRegex: true,
+			wantMaxMetricCardinality: 20000,
+			wantMaxLabelCardinality:  500,
+		},
+		{
+			name:      "none disables all guardrails",
+			config:    Config{Guardrails: "none"},
+			expectNil: true,
+		},
+		{
+			name:                     "explicit subset does not enable cardinality guardrails",
+			config:                   Config{Guardrails: "require-label-matcher,disallow-blanket-regex"},
+			wantRequireLabelMatcher:  true,
+			wantDisallowBlanketRegex: true,
+			wantMaxMetricCardinality: 0,
+			wantMaxLabelCardinality:  0,
+		},
+		{
+			name:                     "explicit subset with user-specified cardinality limits",
+			config:                   Config{Guardrails: "require-label-matcher,disallow-blanket-regex", MaxMetricCardinality: 10000, MaxLabelCardinality: 200},
+			wantRequireLabelMatcher:  true,
+			wantDisallowBlanketRegex: true,
+			wantMaxMetricCardinality: 10000,
+			wantMaxLabelCardinality:  200,
+		},
+		{
+			name:                     "single guardrail only enables that one",
+			config:                   Config{Guardrails: "require-label-matcher"},
+			wantRequireLabelMatcher:  true,
+			wantMaxMetricCardinality: 0,
+			wantMaxLabelCardinality:  0,
+		},
+		{
+			name:                     "all with custom cardinality limits",
+			config:                   Config{Guardrails: "all", MaxMetricCardinality: 50000, MaxLabelCardinality: 1000},
+			wantDisallowExplicitName: true,
+			wantRequireLabelMatcher:  true,
+			wantDisallowBlanketRegex: true,
+			wantMaxMetricCardinality: 50000,
+			wantMaxLabelCardinality:  1000,
+		},
+		{
+			name:      "unknown guardrail returns error",
+			config:    Config{Guardrails: "not-a-guardrail"},
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g, err := tt.config.GetGuardrails()
+			if tt.expectErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.expectNil {
+				if g != nil {
+					t.Fatalf("expected nil guardrails, got %+v", g)
+				}
+				return
+			}
+			if g == nil {
+				t.Fatal("expected non-nil guardrails, got nil")
+			}
+			if g.DisallowExplicitNameLabel != tt.wantDisallowExplicitName {
+				t.Errorf("DisallowExplicitNameLabel = %v, want %v", g.DisallowExplicitNameLabel, tt.wantDisallowExplicitName)
+			}
+			if g.RequireLabelMatcher != tt.wantRequireLabelMatcher {
+				t.Errorf("RequireLabelMatcher = %v, want %v", g.RequireLabelMatcher, tt.wantRequireLabelMatcher)
+			}
+			if g.DisallowBlanketRegex != tt.wantDisallowBlanketRegex {
+				t.Errorf("DisallowBlanketRegex = %v, want %v", g.DisallowBlanketRegex, tt.wantDisallowBlanketRegex)
+			}
+			if g.MaxMetricCardinality != tt.wantMaxMetricCardinality {
+				t.Errorf("MaxMetricCardinality = %v, want %v", g.MaxMetricCardinality, tt.wantMaxMetricCardinality)
+			}
+			if g.MaxLabelCardinality != tt.wantMaxLabelCardinality {
+				t.Errorf("MaxLabelCardinality = %v, want %v", g.MaxLabelCardinality, tt.wantMaxLabelCardinality)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Previously when user passed `--guardrails require-label-matcher,disallow-blanket-regex`, the other guardrails (as `max-metric-cardinality`) was still enabled. 