### PR TITLE
fix: rename the toolset everywhere

### DIFF
--- a/pkg/toolset/config/config.go
+++ b/pkg/toolset/config/config.go
@@ -11,6 +11,8 @@ import (
 	"github.com/rhobs/obs-mcp/pkg/prometheus"
 )
 
+const MetricsToolSetName = "metrics"
+
 // Config holds obs-mcp toolset configuration
 type Config struct {
 	// PrometheusURL is the URL of the Prometheus/Thanos Querier endpoint.
@@ -103,5 +105,5 @@ func obsMCPToolsetParser(_ context.Context, primitive toml.Primitive, md toml.Me
 }
 
 func init() {
-	serverconfig.RegisterToolsetConfig("metrics", obsMCPToolsetParser)
+	serverconfig.RegisterToolsetConfig(MetricsToolSetName, obsMCPToolsetParser)
 }

--- a/pkg/toolset/tools/prometheus_client.go
+++ b/pkg/toolset/tools/prometheus_client.go
@@ -26,7 +26,7 @@ const (
 
 // getConfig retrieves the obs-mcp toolset configuration from params.
 func getConfig(params api.ToolHandlerParams) *toolsetconfig.Config {
-	if cfg, ok := params.GetToolsetConfig("obs-mcp"); ok {
+	if cfg, ok := params.GetToolsetConfig(toolsetconfig.MetricsToolSetName); ok {
 		if obsCfg, ok := cfg.(*toolsetconfig.Config); ok {
 			return obsCfg
 		}

--- a/pkg/toolset/toolset.go
+++ b/pkg/toolset/toolset.go
@@ -6,6 +6,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
 
+	"github.com/rhobs/obs-mcp/pkg/toolset/config"
 	toolset_tools "github.com/rhobs/obs-mcp/pkg/toolset/tools"
 )
 
@@ -16,7 +17,7 @@ var _ api.Toolset = (*Toolset)(nil)
 
 // GetName returns the name of the toolset.
 func (t *Toolset) GetName() string {
-	return "metrics"
+	return config.MetricsToolSetName
 }
 
 // GetDescription returns a human-readable description of the toolset.


### PR DESCRIPTION
I think the main problem was still the:
```
	if cfg, ok := params.GetToolsetConfig("obs-mcp"); ok {

```
in the `prometheus_client.go`