### PR TITLE
Guardrails config simplification and unification

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ go run ./cmd/obs-mcp/ --listen 127.0.0.1:9100 --auth-mode kubeconfig --metrics-b
 
 > [!NOTE]
 >
-> Thanos versions before v0.40.0 do not expose the `/api/v1/status/tsdb` endpoint, so guardrails that rely on TSDB stats (`max-metric-cardinality`, `max-label-cardinality`) will fail. Use `--guardrails=none` when using older Thanos versions. Thanos v0.40.0+ ([#8484](https://github.com/thanos-io/thanos/pull/8484)) added TSDB status support to the Query component, so guardrails should work if your cluster runs that version or later.
+> Thanos versions before v0.40.0 do not expose the `/api/v1/status/tsdb` endpoint, so guardrails that rely on TSDB stats (`max-metric-cardinality`, `disallow-blanket-regex` with `max-label-cardinality > 0`) will fail. Use `--guardrails=none` when using older Thanos versions. Thanos v0.40.0+ ([#8484](https://github.com/thanos-io/thanos/pull/8484)) added TSDB status support to the Query component, so guardrails should work if your cluster runs that version or later.
 
 ```shell
 make run-no-guardrails

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ go run ./cmd/obs-mcp/ --listen 127.0.0.1:9100 --auth-mode kubeconfig --metrics-b
 
 > [!NOTE]
 >
-> Thanos versions before v0.40.0 do not expose the `/api/v1/status/tsdb` endpoint, so guardrails that rely on TSDB stats (`max-metric-cardinality`, `disallow-blanket-regex` with `max-label-cardinality > 0`) will fail. Use `--guardrails=none` when using older Thanos versions. Thanos v0.40.0+ ([#8484](https://github.com/thanos-io/thanos/pull/8484)) added TSDB status support to the Query component, so guardrails should work if your cluster runs that version or later.
+> Thanos versions before v0.40.0 do not expose the `/api/v1/status/tsdb` endpoint, so guardrails that rely on TSDB stats (`max-metric-cardinality`, `disallow-blanket-regex` with `max-label-cardinality > 0`) will fail. Use `--guardrails=none` or `--guardrails='!tsdb'` when using older Thanos versions. Thanos v0.40.0+ ([#8484](https://github.com/thanos-io/thanos/pull/8484)) added TSDB status support to the Query component, so guardrails should work if your cluster runs that version or later.
 
 ```shell
 make run-no-guardrails

--- a/cmd/obs-mcp/main.go
+++ b/cmd/obs-mcp/main.go
@@ -36,7 +36,7 @@ func main() {
 	var logLevel = flag.String("log-level", "info", "Log level: debug, info, warn, error")
 	var metricsBackend = flag.String("metrics-backend", "thanos", "Metrics backend: thanos (default, with prometheus fallback) or prometheus (strict, no fallback)")
 	var guardrails = flag.String("guardrails", "all", "Guardrails configuration: 'all' (default), 'none', or comma-separated list of guardrails to enable (disallow-explicit-name-label, require-label-matcher, disallow-blanket-regex)")
-	var maxMetricCardinality = flag.Uint64("guardrails.max-metric-cardinality", prometheus.DefaultMaxMetricCardinality, "Maximum allowed series count per metric (0 = disabled)")
+	var maxMetricCardinality = flag.Uint64("guardrails.max-metric-cardinality", prometheus.DefaultMaxMetricCardinality, "Maximum allowed series count per metric")
 	var maxLabelCardinality = flag.Uint64("guardrails.max-label-cardinality", prometheus.DefaultMaxLabelCardinality, "Maximum allowed label value count for blanket regex (0 = always disallow blanket regex). Only takes effect if disallow-blanket-regex is enabled.")
 	var fullRangeQueryResponse = flag.Bool("full-range-query-response", false, "Return full data points for range queries")
 	flag.Parse()

--- a/cmd/obs-mcp/main.go
+++ b/cmd/obs-mcp/main.go
@@ -89,7 +89,7 @@ func main() {
 	// Reject deprecated use of 0 to disable the metric cardinality guardrail.
 	if isFlagExplicitlySet("guardrails.max-metric-cardinality") && *maxMetricCardinality == 0 {
 		log.Fatalf("--guardrails.max-metric-cardinality=0 is no longer supported to disable the guardrail; "+
-			"use %q in --guardrails instead", "!"+prometheus.GuardrailMaxMetricCardinality)
+			"use '!%s' in --guardrails instead", prometheus.GuardrailMaxMetricCardinality)
 	}
 
 	// Reject cardinality flags that have no effect given the active guardrails.

--- a/cmd/obs-mcp/main.go
+++ b/cmd/obs-mcp/main.go
@@ -86,6 +86,12 @@ func main() {
 		log.Fatalf("Invalid guardrails configuration: %v", err)
 	}
 
+	// Reject deprecated use of 0 to disable the metric cardinality guardrail.
+	if isFlagExplicitlySet("guardrails.max-metric-cardinality") && *maxMetricCardinality == 0 {
+		log.Fatalf("--guardrails.max-metric-cardinality=0 is no longer supported to disable the guardrail; "+
+			"use %q in --guardrails instead", "!"+prometheus.GuardrailMaxMetricCardinality)
+	}
+
 	// Reject cardinality flags that have no effect given the active guardrails.
 	if isFlagExplicitlySet("guardrails.max-metric-cardinality") &&
 		(parsedGuardrails == nil || !parsedGuardrails.ForceMaxMetricCardinality) {

--- a/cmd/obs-mcp/main.go
+++ b/cmd/obs-mcp/main.go
@@ -36,8 +36,8 @@ func main() {
 	var logLevel = flag.String("log-level", "info", "Log level: debug, info, warn, error")
 	var metricsBackend = flag.String("metrics-backend", "thanos", "Metrics backend: thanos (default, with prometheus fallback) or prometheus (strict, no fallback)")
 	var guardrails = flag.String("guardrails", "all", "Guardrails configuration: 'all' (default), 'none', or comma-separated list of guardrails to enable (disallow-explicit-name-label, require-label-matcher, disallow-blanket-regex)")
-	var maxMetricCardinality = flag.Uint64("guardrails.max-metric-cardinality", 20000, "Maximum allowed series count per metric (0 = disabled)")
-	var maxLabelCardinality = flag.Uint64("guardrails.max-label-cardinality", 500, "Maximum allowed label value count for blanket regex (0 = always disallow blanket regex). Only takes effect if disallow-blanket-regex is enabled.")
+	var maxMetricCardinality = flag.Uint64("guardrails.max-metric-cardinality", prometheus.DefaultMaxMetricCardinality, "Maximum allowed series count per metric (0 = disabled)")
+	var maxLabelCardinality = flag.Uint64("guardrails.max-label-cardinality", prometheus.DefaultMaxLabelCardinality, "Maximum allowed label value count for blanket regex (0 = always disallow blanket regex). Only takes effect if disallow-blanket-regex is enabled.")
 	var fullRangeQueryResponse = flag.Bool("full-range-query-response", false, "Return full data points for range queries")
 	flag.Parse()
 
@@ -86,10 +86,26 @@ func main() {
 		log.Fatalf("Invalid guardrails configuration: %v", err)
 	}
 
-	// Set max metric cardinality and max label cardinality if guardrails are enabled
+	// Reject cardinality flags that have no effect given the active guardrails.
+	if isFlagExplicitlySet("guardrails.max-metric-cardinality") &&
+		(parsedGuardrails == nil || !parsedGuardrails.ForceMaxMetricCardinality) {
+		log.Fatalf("--guardrails.max-metric-cardinality has no effect: add %q to --guardrails to enable the metric cardinality guardrail",
+			prometheus.GuardrailMaxMetricCardinality)
+	}
+	if isFlagExplicitlySet("guardrails.max-label-cardinality") &&
+		(parsedGuardrails == nil || !parsedGuardrails.DisallowBlanketRegex) {
+		log.Fatalf("--guardrails.max-label-cardinality has no effect: add %q to --guardrails to enable the blanket-regex guardrail",
+			prometheus.GuardrailDisallowBlanketRegex)
+	}
+
+	// Set max metric cardinality and max label cardinality if the corresponding guardrails are enabled.
 	if parsedGuardrails != nil {
-		parsedGuardrails.MaxMetricCardinality = *maxMetricCardinality
-		parsedGuardrails.MaxLabelCardinality = *maxLabelCardinality
+		if parsedGuardrails.ForceMaxMetricCardinality {
+			parsedGuardrails.MaxMetricCardinality = *maxMetricCardinality
+		}
+		if parsedGuardrails.DisallowBlanketRegex {
+			parsedGuardrails.MaxLabelCardinality = *maxLabelCardinality
+		}
 	}
 
 	// Create MCP options

--- a/cmd/obs-mcp/main.go
+++ b/cmd/obs-mcp/main.go
@@ -35,9 +35,20 @@ func main() {
 	var insecure = flag.Bool("insecure", false, "Skip TLS certificate verification")
 	var logLevel = flag.String("log-level", "info", "Log level: debug, info, warn, error")
 	var metricsBackend = flag.String("metrics-backend", "thanos", "Metrics backend: thanos (default, with prometheus fallback) or prometheus (strict, no fallback)")
-	var guardrails = flag.String("guardrails", "all", "Guardrails configuration: 'all' (default), 'none', or comma-separated list of guardrails to enable (disallow-explicit-name-label, require-label-matcher, disallow-blanket-regex)")
+	var guardrails = flag.String("guardrails", "all",
+		"Which safety checks are enforced on PromQL queries.\n"+
+			"  'all': enable every guardrail\n"+
+			"  'none': disable every guardrail\n"+
+			"  Comma-separated list: enable only the named guardrails, e.g.\n"+
+			"      disallow-explicit-name-label,require-label-matcher,disallow-blanket-regex,max-metric-cardinality\n"+
+			"  Comma-separated list with ! prefix: disable the listed guardrails (enable the rest), e.g.\n"+
+			"      !disallow-blanket-regex,!require-label-matcher\n"+
+			"  '!tsdb' is a shortcut that disables both TSDB-dependent guardrails at once\n"+
+			"      (max-metric-cardinality and disallow-blanket-regex)\n")
 	var maxMetricCardinality = flag.Uint64("guardrails.max-metric-cardinality", prometheus.DefaultMaxMetricCardinality, "Maximum allowed series count per metric")
-	var maxLabelCardinality = flag.Uint64("guardrails.max-label-cardinality", prometheus.DefaultMaxLabelCardinality, "Maximum allowed label value count for blanket regex (0 = always disallow blanket regex). Only takes effect if disallow-blanket-regex is enabled.")
+	var maxLabelCardinality = flag.Uint64("guardrails.max-label-cardinality", prometheus.DefaultMaxLabelCardinality,
+		"Maximum allowed label value count for blanket regex (0 = always disallow blanket regex).\n"+
+			"Only takes effect if disallow-blanket-regex is enabled.")
 	var fullRangeQueryResponse = flag.Bool("full-range-query-response", false, "Return full data points for range queries")
 	flag.Parse()
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -72,15 +72,15 @@ obs-mcp includes query guardrails that prevent expensive or unsafe PromQL querie
 | Guardrail | What it checks |
 |-----------|----------------|
 | `max-metric-cardinality` | Rejects queries against metrics with more series than the configured limit |
-| `disallow-blanket-regex` | Rejects blanket regex matchers (`=~".+"`) on high-cardinality labels |
+| `disallow-blanket-regex` (with `max-label-cardinality > 0`)| Rejects blanket regex matchers (`=~".+"`) on high-cardinality labels |
 
 **Thanos compatibility:**
 
 - **Thanos v0.40.0+** (Oct 2025): The Query component exposes `/api/v1/status/tsdb` ([#8484](https://github.com/thanos-io/thanos/pull/8484)), so all guardrails work.
-- **Thanos < v0.40.0**: The TSDB status endpoint is not available on the Query component. Use `--guardrails=none` or disable only the cardinality guardrail while keeping the others enabled:
+- **Thanos < v0.40.0**: The TSDB status endpoint is not available on the Query component. Use `--guardrails=none` or use the `!tsdb` shortcut to disable only the TSDB-dependent guardrails while keeping the others enabled:
 
   ```shell
-  --guardrails=!max-metric-cardinality,!disallow-blanket-regex 
+  --guardrails=!tsdb
   ```
 
 - **Prometheus**: All guardrails work with any supported Prometheus version.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -72,15 +72,15 @@ obs-mcp includes query guardrails that prevent expensive or unsafe PromQL querie
 | Guardrail | What it checks |
 |-----------|----------------|
 | `max-metric-cardinality` | Rejects queries against metrics with more series than the configured limit |
-| `max-label-cardinality` (with `disallow-blanket-regex`) | Rejects blanket regex matchers (`=~".+"`) on high-cardinality labels |
+| `disallow-blanket-regex` | Rejects blanket regex matchers (`=~".+"`) on high-cardinality labels |
 
 **Thanos compatibility:**
 
 - **Thanos v0.40.0+** (Oct 2025): The Query component exposes `/api/v1/status/tsdb` ([#8484](https://github.com/thanos-io/thanos/pull/8484)), so all guardrails work.
-- **Thanos < v0.40.0**: The TSDB status endpoint is not available on the Query component. Use `--guardrails=none` or disable only the cardinality guardrails while keeping the others enabled:
+- **Thanos < v0.40.0**: The TSDB status endpoint is not available on the Query component. Use `--guardrails=none` or disable only the cardinality guardrail while keeping the others enabled:
 
   ```shell
-  --guardrails=disallow-explicit-name-label,require-label-matcher,disallow-blanket-regex --guardrails.max-label-cardinality=0
+  --guardrails=!max-metric-cardinality,!disallow-blanket-regex 
   ```
 
 - **Prometheus**: All guardrails work with any supported Prometheus version.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -80,7 +80,7 @@ obs-mcp includes query guardrails that prevent expensive or unsafe PromQL querie
 - **Thanos < v0.40.0**: The TSDB status endpoint is not available on the Query component. Use `--guardrails=none` or use the `!tsdb` shortcut to disable only the TSDB-dependent guardrails while keeping the others enabled:
 
   ```shell
-  --guardrails=!tsdb
+  --guardrails='!tsdb'
   ```
 
 - **Prometheus**: All guardrails work with any supported Prometheus version.

--- a/pkg/prometheus/guardrails.go
+++ b/pkg/prometheus/guardrails.go
@@ -19,6 +19,12 @@ const (
 	GuardrailMaxLabelCardinality       = "max-label-cardinality"
 )
 
+// Default cardinality thresholds
+const (
+	DefaultMaxMetricCardinality uint64 = 20000
+	DefaultMaxLabelCardinality  uint64 = 500
+)
+
 // GuardrailViolation is returned when a query violates a specific guardrail rule.
 // It carries the guardrail name for structured logging.
 type GuardrailViolation struct {
@@ -38,7 +44,10 @@ type Guardrails struct {
 	RequireLabelMatcher bool
 	// DisallowBlanketRegex prevents expensive regex patterns like .* or .+ on any label
 	DisallowBlanketRegex bool
-	// MaxMetricCardinality sets the maximum allowed series count per metric (0 = disabled)
+	// ForceMaxMetricCardinality enables the maximum series count per metric guardrail
+	ForceMaxMetricCardinality bool
+	// MaxMetricCardinality sets the maximum allowed series count per metric
+	// (only enforced when ForceMaxMetricCardinality is true)
 	MaxMetricCardinality uint64
 	// MaxLabelCardinality sets the maximum allowed label value count for blanket regex
 	// (0 = always disallow regex matcher provided DisallowBlanketRegex is true)
@@ -46,13 +55,16 @@ type Guardrails struct {
 }
 
 // DefaultGuardrails returns a Guardrails instance with all safety checks enabled.
-func DefaultGuardrails() *Guardrails {
+// DefaultGuardrails returns a Guardrails instance with default numeric thresholds.
+// When enableAll is true, all boolean guardrails are also enabled (equivalent to "all").
+func DefaultGuardrails(enableAll bool) *Guardrails {
 	return &Guardrails{
-		DisallowExplicitNameLabel: true,
-		RequireLabelMatcher:       true,
-		DisallowBlanketRegex:      true,
-		MaxMetricCardinality:      20000,
-		MaxLabelCardinality:       500,
+		DisallowExplicitNameLabel: enableAll,
+		RequireLabelMatcher:       enableAll,
+		DisallowBlanketRegex:      enableAll,
+		ForceMaxMetricCardinality: enableAll,
+		MaxMetricCardinality:      DefaultMaxMetricCardinality,
+		MaxLabelCardinality:       DefaultMaxLabelCardinality,
 	}
 }
 
@@ -63,10 +75,10 @@ func ParseGuardrails(value string) (*Guardrails, error) {
 	case "none":
 		return nil, nil
 	case "all", "":
-		return DefaultGuardrails(), nil
+		return DefaultGuardrails(true), nil
 	}
 
-	g := &Guardrails{}
+	g := DefaultGuardrails(false)
 	names := strings.SplitSeq(value, ",")
 	for name := range names {
 		name = strings.TrimSpace(strings.ToLower(name))
@@ -81,10 +93,12 @@ func ParseGuardrails(value string) (*Guardrails, error) {
 			g.RequireLabelMatcher = true
 		case GuardrailDisallowBlanketRegex:
 			g.DisallowBlanketRegex = true
+		case GuardrailMaxMetricCardinality:
+			g.ForceMaxMetricCardinality = true
 		default:
-			return nil, fmt.Errorf("unknown guardrail: %q (valid options: %s, %s, %s)",
+			return nil, fmt.Errorf("unknown guardrail: %q (valid options: %s, %s, %s, %s)",
 				name, GuardrailDisallowExplicitNameLabel, GuardrailRequireLabelMatcher,
-				GuardrailDisallowBlanketRegex)
+				GuardrailDisallowBlanketRegex, GuardrailMaxMetricCardinality)
 		}
 	}
 
@@ -102,7 +116,7 @@ func ParseGuardrails(value string) (*Guardrails, error) {
 //
 //nolint:gocyclo // complex validation logic, refactoring would reduce readability
 func (g *Guardrails) IsSafeQuery(ctx context.Context, query string, client v1.API) (bool, error) {
-	if ((g.DisallowBlanketRegex && g.MaxLabelCardinality > 0) || (g.MaxMetricCardinality > 0)) && (client == nil || ctx == nil) {
+	if ((g.DisallowBlanketRegex && g.MaxLabelCardinality > 0) || g.ForceMaxMetricCardinality) && (client == nil || ctx == nil) {
 		return false, fmt.Errorf("cannot verify cardinality without TSDB client")
 	}
 
@@ -158,7 +172,7 @@ func (g *Guardrails) IsSafeQuery(ctx context.Context, query string, client v1.AP
 	}
 
 	// Check metric cardinality
-	if g.MaxMetricCardinality > 0 {
+	if g.ForceMaxMetricCardinality {
 		metricNames, err := ExtractMetricNames(query)
 		if err != nil {
 			return false, fmt.Errorf("failed to extract metric names: %w", err)

--- a/pkg/prometheus/guardrails.go
+++ b/pkg/prometheus/guardrails.go
@@ -207,7 +207,7 @@ func (g *Guardrails) IsSafeQuery(ctx context.Context, query string, client v1.AP
 				return false, fmt.Errorf(
 					"cannot enforce max-metric-cardinality guardrail: TSDB stats endpoint is unavailable on this backend "+
 						"(Thanos Querier < v0.40.0 does not implement /api/v1/status/tsdb); "+
-						"disable this guardrail with --guardrails require-label-matcher,disallow-blanket-regex: %w", err)
+						"disable this guardrail with --guardrails '!tsdb': %w", err)
 			}
 
 			seriesCountByMetric := make(map[string]uint64)
@@ -250,7 +250,7 @@ func (g *Guardrails) IsSafeQuery(ctx context.Context, query string, client v1.AP
 				return false, fmt.Errorf(
 					"cannot enforce max-label-cardinality guardrail: TSDB stats endpoint is unavailable on this backend "+
 						"(Thanos Querier < v0.40.0 does not implement /api/v1/status/tsdb); "+
-						"disable this guardrail with --guardrails require-label-matcher,disallow-blanket-regex: %w", err)
+						"disable this guardrail with --guardrails '!tsdb': %w", err)
 			}
 
 			labelValueCountByLabel := make(map[string]uint64)

--- a/pkg/prometheus/guardrails.go
+++ b/pkg/prometheus/guardrails.go
@@ -16,6 +16,12 @@ const (
 	GuardrailRequireLabelMatcher       = "require-label-matcher"
 	GuardrailDisallowBlanketRegex      = "disallow-blanket-regex"
 	GuardrailMaxMetricCardinality      = "max-metric-cardinality"
+
+	// GuardrailShortcutTSDB is a shortcut that refers to both TSDB-dependent
+	// guardrails (max-metric-cardinality and disallow-blanket-regex). Use
+	// "!tsdb" to disable both when the backend does not expose
+	// /api/v1/status/tsdb (e.g. Thanos Querier < v0.40.0).
+	GuardrailShortcutTSDB = "tsdb"
 )
 
 // Default cardinality thresholds
@@ -107,6 +113,12 @@ func ParseGuardrails(value string) (*Guardrails, error) {
 			g.DisallowBlanketRegex = !defaultValue
 		case GuardrailMaxMetricCardinality:
 			g.ForceMaxMetricCardinality = !defaultValue
+		case GuardrailShortcutTSDB:
+			if !negative {
+				return nil, fmt.Errorf("%q is only valid as a negative shortcut (!tsdb); use individual guardrail names in positive mode", GuardrailShortcutTSDB)
+			}
+			g.ForceMaxMetricCardinality = false
+			g.DisallowBlanketRegex = false
 		default:
 			return nil, fmt.Errorf("unknown guardrail: %q (valid options: %s, %s, %s, %s)",
 				name, GuardrailDisallowExplicitNameLabel, GuardrailRequireLabelMatcher,

--- a/pkg/prometheus/guardrails.go
+++ b/pkg/prometheus/guardrails.go
@@ -59,7 +59,6 @@ type Guardrails struct {
 	MaxLabelCardinality uint64
 }
 
-// DefaultGuardrails returns a Guardrails instance with all safety checks enabled.
 // DefaultGuardrails returns a Guardrails instance with default numeric thresholds.
 // When enableAll is true, all boolean guardrails are also enabled (equivalent to "all").
 func DefaultGuardrails(enableAll bool) *Guardrails {

--- a/pkg/prometheus/guardrails.go
+++ b/pkg/prometheus/guardrails.go
@@ -16,7 +16,6 @@ const (
 	GuardrailRequireLabelMatcher       = "require-label-matcher"
 	GuardrailDisallowBlanketRegex      = "disallow-blanket-regex"
 	GuardrailMaxMetricCardinality      = "max-metric-cardinality"
-	GuardrailMaxLabelCardinality       = "max-label-cardinality"
 )
 
 // Default cardinality thresholds
@@ -69,39 +68,51 @@ func DefaultGuardrails(enableAll bool) *Guardrails {
 }
 
 func ParseGuardrails(value string) (*Guardrails, error) {
-	value = strings.TrimSpace(value)
+	value = strings.TrimSpace(strings.ToLower(value))
 
-	switch strings.ToLower(value) {
+	switch value {
 	case "none":
 		return nil, nil
 	case "all", "":
 		return DefaultGuardrails(true), nil
 	}
 
-	g := DefaultGuardrails(false)
-	names := strings.SplitSeq(value, ",")
-	for name := range names {
-		name = strings.TrimSpace(strings.ToLower(name))
+	// Determine mode from whether any token carries a "!" prefix, then verify
+	// all tokens are consistent (mixing positive and negative is not allowed).
+	negative := strings.Contains(value, "!")
+	var names []string
+	for name := range strings.SplitSeq(value, ",") {
+		name = strings.TrimSpace(name)
 		if name == "" {
 			continue
 		}
+		if negative != strings.HasPrefix(name, "!") {
+			return nil, fmt.Errorf("cannot mix positive and negative guardrail names: " +
+				"use either explicit names to enable, or !name to disable from the full set")
+		}
+		name = strings.TrimPrefix(name, "!")
+		names = append(names, name)
+	}
 
+	// In negative mode all guardrails start enabled; in positive mode all start disabled.
+	defaultValue := negative
+	g := DefaultGuardrails(defaultValue)
+	for _, name := range names {
 		switch name {
 		case GuardrailDisallowExplicitNameLabel:
-			g.DisallowExplicitNameLabel = true
+			g.DisallowExplicitNameLabel = !defaultValue
 		case GuardrailRequireLabelMatcher:
-			g.RequireLabelMatcher = true
+			g.RequireLabelMatcher = !defaultValue
 		case GuardrailDisallowBlanketRegex:
-			g.DisallowBlanketRegex = true
+			g.DisallowBlanketRegex = !defaultValue
 		case GuardrailMaxMetricCardinality:
-			g.ForceMaxMetricCardinality = true
+			g.ForceMaxMetricCardinality = !defaultValue
 		default:
 			return nil, fmt.Errorf("unknown guardrail: %q (valid options: %s, %s, %s, %s)",
 				name, GuardrailDisallowExplicitNameLabel, GuardrailRequireLabelMatcher,
 				GuardrailDisallowBlanketRegex, GuardrailMaxMetricCardinality)
 		}
 	}
-
 	return g, nil
 }
 
@@ -239,7 +250,7 @@ func (g *Guardrails) IsSafeQuery(ctx context.Context, query string, client v1.AP
 				if count, exists := labelValueCountByLabel[labelName]; exists {
 					if count > g.MaxLabelCardinality {
 						return false, &GuardrailViolation{
-							Guardrail: GuardrailMaxLabelCardinality,
+							Guardrail: GuardrailDisallowBlanketRegex,
 							Message:   fmt.Sprintf("label %q has cardinality %d, which exceeds maximum allowed %d for blanket regex", labelName, count, g.MaxLabelCardinality),
 						}
 					}

--- a/pkg/prometheus/guardrails_test.go
+++ b/pkg/prometheus/guardrails_test.go
@@ -115,6 +115,23 @@ func TestParseGuardrails(t *testing.T) {
 			},
 		},
 		{
+			name:  "!tsdb shortcut disables both TSDB-dependent guardrails",
+			input: "!" + GuardrailShortcutTSDB,
+			wantGuardrails: &Guardrails{
+				DisallowExplicitNameLabel: true,
+				RequireLabelMatcher:       true,
+				DisallowBlanketRegex:      false,
+				ForceMaxMetricCardinality: false,
+				MaxMetricCardinality:      DefaultMaxMetricCardinality,
+				MaxLabelCardinality:       DefaultMaxLabelCardinality,
+			},
+		},
+		{
+			name:    "tsdb shortcut without ! is not allowed",
+			input:   GuardrailShortcutTSDB,
+			wantErr: true,
+		},
+		{
 			name:  "negative max-metric-cardinality disables ForceMaxMetricCardinality",
 			input: "!" + GuardrailMaxMetricCardinality,
 			wantGuardrails: &Guardrails{

--- a/pkg/prometheus/guardrails_test.go
+++ b/pkg/prometheus/guardrails_test.go
@@ -587,6 +587,7 @@ func TestGuardrails_MaxLabelCardinalityWithMockedTSDB(t *testing.T) {
 			DisallowExplicitNameLabel: false,
 			RequireLabelMatcher:       false,
 			DisallowBlanketRegex:      true,
+			ForceMaxMetricCardinality: true,
 			MaxMetricCardinality:      10000, // Metric threshold
 			MaxLabelCardinality:       100,   // Label threshold
 		}
@@ -613,6 +614,7 @@ func TestGuardrails_MaxLabelCardinalityWithMockedTSDB(t *testing.T) {
 			DisallowExplicitNameLabel: false,
 			RequireLabelMatcher:       false,
 			DisallowBlanketRegex:      true,
+			ForceMaxMetricCardinality: true,
 			MaxMetricCardinality:      10000,
 			MaxLabelCardinality:       100,
 		}

--- a/pkg/prometheus/guardrails_test.go
+++ b/pkg/prometheus/guardrails_test.go
@@ -9,6 +9,125 @@ import (
 	"github.com/prometheus/common/model"
 )
 
+func TestParseGuardrails(t *testing.T) {
+	allEnabled := DefaultGuardrails(true)
+
+	tests := []struct {
+		name           string
+		input          string
+		wantNil        bool // expect (nil, nil)
+		wantErr        bool
+		wantGuardrails *Guardrails
+	}{
+		// Special keywords
+		{
+			name:    "none disables all guardrails",
+			input:   "none",
+			wantNil: true,
+		},
+		{
+			name:    "NONE is case-insensitive",
+			input:   "NONE",
+			wantNil: true,
+		},
+		{
+			name:           "all enables all guardrails",
+			input:          "all",
+			wantGuardrails: allEnabled,
+		},
+		{
+			name:           "empty string enables all guardrails",
+			input:          "",
+			wantGuardrails: allEnabled,
+		},
+		{
+			name:  "disallow-explicit-name-label only",
+			input: GuardrailDisallowExplicitNameLabel,
+			wantGuardrails: &Guardrails{
+				DisallowExplicitNameLabel: true,
+				MaxMetricCardinality:      DefaultMaxMetricCardinality,
+				MaxLabelCardinality:       DefaultMaxLabelCardinality,
+			},
+		},
+		{
+			name:  "two guardrails",
+			input: GuardrailDisallowExplicitNameLabel + "," + GuardrailRequireLabelMatcher,
+			wantGuardrails: &Guardrails{
+				DisallowExplicitNameLabel: true,
+				RequireLabelMatcher:       true,
+				MaxMetricCardinality:      DefaultMaxMetricCardinality,
+				MaxLabelCardinality:       DefaultMaxLabelCardinality,
+			},
+		},
+		// Whitespace tolerance
+		{
+			name:  "spaces around commas are trimmed",
+			input: GuardrailDisallowExplicitNameLabel + " , " + GuardrailRequireLabelMatcher,
+			wantGuardrails: &Guardrails{
+				DisallowExplicitNameLabel: true,
+				RequireLabelMatcher:       true,
+				MaxMetricCardinality:      DefaultMaxMetricCardinality,
+				MaxLabelCardinality:       DefaultMaxLabelCardinality,
+			},
+		},
+		{
+			name:  "empty segments from extra commas are ignored",
+			input: "," + GuardrailRequireLabelMatcher + ",",
+			wantGuardrails: &Guardrails{
+				RequireLabelMatcher:  true,
+				MaxMetricCardinality: DefaultMaxMetricCardinality,
+				MaxLabelCardinality:  DefaultMaxLabelCardinality,
+			},
+		},
+		// Case insensitivity for named guardrails
+		{
+			name:  "guardrail name is case-insensitive",
+			input: "REQUIRE-LABEL-MATCHER",
+			wantGuardrails: &Guardrails{
+				RequireLabelMatcher:  true,
+				MaxMetricCardinality: DefaultMaxMetricCardinality,
+				MaxLabelCardinality:  DefaultMaxLabelCardinality,
+			},
+		},
+		// Error cases
+		{
+			name:    "unknown name mixed with valid name returns error",
+			input:   GuardrailRequireLabelMatcher + ",bad-name",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseGuardrails(tt.input)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("ParseGuardrails(%q) expected error, got nil", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseGuardrails(%q) unexpected error: %v", tt.input, err)
+			}
+
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("ParseGuardrails(%q) = %+v, want nil", tt.input, got)
+				}
+				return
+			}
+
+			if got == nil {
+				t.Fatalf("ParseGuardrails(%q) = nil, want non-nil", tt.input)
+			}
+			if *got != *tt.wantGuardrails {
+				t.Errorf("ParseGuardrails(%q)\n got  %+v\n want %+v", tt.input, *got, *tt.wantGuardrails)
+			}
+		})
+	}
+}
+
 func TestGuardrails_IsSafeQuery(t *testing.T) {
 	// Use static guardrails without cardinality limits (no TSDB client needed)
 	g := &Guardrails{

--- a/pkg/prometheus/guardrails_test.go
+++ b/pkg/prometheus/guardrails_test.go
@@ -89,10 +89,74 @@ func TestParseGuardrails(t *testing.T) {
 				MaxLabelCardinality:  DefaultMaxLabelCardinality,
 			},
 		},
+		// Negative guardrails (! prefix disables a guardrail, all others remain enabled)
+		{
+			name:  "single negative guardrail disables only that one",
+			input: "!" + GuardrailRequireLabelMatcher,
+			wantGuardrails: &Guardrails{
+				DisallowExplicitNameLabel: true,
+				RequireLabelMatcher:       false,
+				DisallowBlanketRegex:      true,
+				ForceMaxMetricCardinality: true,
+				MaxMetricCardinality:      DefaultMaxMetricCardinality,
+				MaxLabelCardinality:       DefaultMaxLabelCardinality,
+			},
+		},
+		{
+			name:  "multiple negative guardrails disable each listed one",
+			input: "!" + GuardrailDisallowExplicitNameLabel + ",!" + GuardrailRequireLabelMatcher,
+			wantGuardrails: &Guardrails{
+				DisallowExplicitNameLabel: false,
+				RequireLabelMatcher:       false,
+				DisallowBlanketRegex:      true,
+				ForceMaxMetricCardinality: true,
+				MaxMetricCardinality:      DefaultMaxMetricCardinality,
+				MaxLabelCardinality:       DefaultMaxLabelCardinality,
+			},
+		},
+		{
+			name:  "negative max-metric-cardinality disables ForceMaxMetricCardinality",
+			input: "!" + GuardrailMaxMetricCardinality,
+			wantGuardrails: &Guardrails{
+				DisallowExplicitNameLabel: true,
+				RequireLabelMatcher:       true,
+				DisallowBlanketRegex:      true,
+				ForceMaxMetricCardinality: false,
+				MaxMetricCardinality:      DefaultMaxMetricCardinality,
+				MaxLabelCardinality:       DefaultMaxLabelCardinality,
+			},
+		},
+		{
+			name:  "negative guardrail name is case-insensitive",
+			input: "!" + "REQUIRE-LABEL-MATCHER",
+			wantGuardrails: &Guardrails{
+				DisallowExplicitNameLabel: true,
+				RequireLabelMatcher:       false,
+				DisallowBlanketRegex:      true,
+				ForceMaxMetricCardinality: true,
+				MaxMetricCardinality:      DefaultMaxMetricCardinality,
+				MaxLabelCardinality:       DefaultMaxLabelCardinality,
+			},
+		},
 		// Error cases
 		{
 			name:    "unknown name mixed with valid name returns error",
 			input:   GuardrailRequireLabelMatcher + ",bad-name",
+			wantErr: true,
+		},
+		{
+			name:    "unknown negative name returns error",
+			input:   "!bad-name",
+			wantErr: true,
+		},
+		{
+			name:    "mixing positive and negative guardrails returns error",
+			input:   GuardrailDisallowExplicitNameLabel + ",!" + GuardrailRequireLabelMatcher,
+			wantErr: true,
+		},
+		{
+			name:    "mixing negative and positive guardrails returns error",
+			input:   "!" + GuardrailDisallowExplicitNameLabel + "," + GuardrailRequireLabelMatcher,
 			wantErr: true,
 		},
 	}

--- a/pkg/prometheus/loader.go
+++ b/pkg/prometheus/loader.go
@@ -53,7 +53,7 @@ func NewPrometheusClient(apiConfig api.Config) (*RealLoader, error) {
 	v1api := v1.NewAPI(client)
 	return &RealLoader{
 		client:     v1api,
-		guardrails: DefaultGuardrails(),
+		guardrails: DefaultGuardrails(true),
 		backend:    backend,
 	}, nil
 }

--- a/pkg/toolset/config/config.go
+++ b/pkg/toolset/config/config.go
@@ -106,23 +106,21 @@ func (c *Config) GetGuardrails() (*prometheus.Guardrails, error) {
 		return nil, err
 	}
 
-	if guardrails != nil {
-		if c.MaxMetricCardinality != nil {
-			if !guardrails.ForceMaxMetricCardinality {
-				return nil, fmt.Errorf(
-					"max_metric_cardinality is set but the %q guardrail is not enabled",
-					prometheus.GuardrailMaxMetricCardinality)
-			}
-			guardrails.MaxMetricCardinality = *c.MaxMetricCardinality
+	if c.MaxMetricCardinality != nil {
+		if guardrails == nil || !guardrails.ForceMaxMetricCardinality {
+			return nil, fmt.Errorf(
+				"max_metric_cardinality is set but the %q guardrail is not enabled",
+				prometheus.GuardrailMaxMetricCardinality)
 		}
-		if c.MaxLabelCardinality != nil {
-			if !guardrails.DisallowBlanketRegex {
-				return nil, fmt.Errorf(
-					"max_label_cardinality is set but the %q guardrail is not enabled",
-					prometheus.GuardrailDisallowBlanketRegex)
-			}
-			guardrails.MaxLabelCardinality = *c.MaxLabelCardinality
+		guardrails.MaxMetricCardinality = *c.MaxMetricCardinality
+	}
+	if c.MaxLabelCardinality != nil {
+		if guardrails == nil || !guardrails.DisallowBlanketRegex {
+			return nil, fmt.Errorf(
+				"max_label_cardinality is set but the %q guardrail is not enabled",
+				prometheus.GuardrailDisallowBlanketRegex)
 		}
+		guardrails.MaxLabelCardinality = *c.MaxLabelCardinality
 	}
 
 	return guardrails, nil

--- a/pkg/toolset/config/config.go
+++ b/pkg/toolset/config/config.go
@@ -109,6 +109,11 @@ func (c *Config) GetGuardrails() (*prometheus.Guardrails, error) {
 				"max_metric_cardinality is set but the %q guardrail is not enabled",
 				prometheus.GuardrailMaxMetricCardinality)
 		}
+		if *c.MaxMetricCardinality == 0 {
+			return nil, fmt.Errorf(
+				"max_metric_cardinality = 0 is not supported to disable the guardrail; use '!%s' in guardrails instead",
+				prometheus.GuardrailMaxMetricCardinality)
+		}
 		guardrails.MaxMetricCardinality = *c.MaxMetricCardinality
 	}
 	if c.MaxLabelCardinality != nil {

--- a/pkg/toolset/config/config.go
+++ b/pkg/toolset/config/config.go
@@ -53,15 +53,14 @@ type Config struct {
 	Guardrails string `toml:"guardrails,omitempty"`
 
 	// MaxMetricCardinality is the maximum allowed series count per metric.
-	// Set to 0 to disable this check.
-	// Default: 20000
-	MaxMetricCardinality uint64 `toml:"max_metric_cardinality,omitempty"`
+	// When unset, the default of 20000 is used.
+	MaxMetricCardinality *uint64 `toml:"max_metric_cardinality,omitempty"`
 
 	// MaxLabelCardinality is the maximum allowed label value count for blanket regex.
 	// Only takes effect if disallow-blanket-regex is enabled.
-	// Set to 0 to always disallow blanket regex.
-	// Default: 500
-	MaxLabelCardinality uint64 `toml:"max_label_cardinality,omitempty"`
+	// When unset, the default of 500 is used.
+	// Set to 0 to always disallow blanket regex regardless of cardinality.
+	MaxLabelCardinality *uint64 `toml:"max_label_cardinality,omitempty"`
 
 	// RangeQueryFullResponse controls whether range queries return full data points
 	// instead of summary statistics.
@@ -108,21 +107,21 @@ func (c *Config) GetGuardrails() (*prometheus.Guardrails, error) {
 	}
 
 	if guardrails != nil {
-		if c.MaxMetricCardinality != 0 {
+		if c.MaxMetricCardinality != nil {
 			if !guardrails.ForceMaxMetricCardinality {
 				return nil, fmt.Errorf(
 					"max_metric_cardinality is set but the %q guardrail is not enabled",
 					prometheus.GuardrailMaxMetricCardinality)
 			}
-			guardrails.MaxMetricCardinality = c.MaxMetricCardinality
+			guardrails.MaxMetricCardinality = *c.MaxMetricCardinality
 		}
-		if c.MaxLabelCardinality != 0 {
+		if c.MaxLabelCardinality != nil {
 			if !guardrails.DisallowBlanketRegex {
 				return nil, fmt.Errorf(
 					"max_label_cardinality is set but the %q guardrail is not enabled",
 					prometheus.GuardrailDisallowBlanketRegex)
 			}
-			guardrails.MaxLabelCardinality = c.MaxLabelCardinality
+			guardrails.MaxLabelCardinality = *c.MaxLabelCardinality
 		}
 	}
 

--- a/pkg/toolset/config/config.go
+++ b/pkg/toolset/config/config.go
@@ -76,11 +76,8 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("invalid auth_mode: %q (valid options: %q, %q)", c.AuthMode, AuthModeHeader, AuthModeKubeConfig)
 	}
 
-	if c.Guardrails != "" {
-		_, err := prometheus.ParseGuardrails(c.Guardrails)
-		if err != nil {
-			return fmt.Errorf("invalid guardrails configuration: %w", err)
-		}
+	if _, err := c.GetGuardrails(); err != nil {
+		return err
 	}
 
 	return nil

--- a/pkg/toolset/config/config.go
+++ b/pkg/toolset/config/config.go
@@ -108,18 +108,22 @@ func (c *Config) GetGuardrails() (*prometheus.Guardrails, error) {
 	}
 
 	if guardrails != nil {
-		// Apply cardinality limits
-		maxMetricCard := c.MaxMetricCardinality
-		if maxMetricCard == 0 {
-			maxMetricCard = 20000 // default
+		if c.MaxMetricCardinality != 0 {
+			if !guardrails.ForceMaxMetricCardinality {
+				return nil, fmt.Errorf(
+					"max_metric_cardinality is set but the %q guardrail is not enabled",
+					prometheus.GuardrailMaxMetricCardinality)
+			}
+			guardrails.MaxMetricCardinality = c.MaxMetricCardinality
 		}
-		guardrails.MaxMetricCardinality = maxMetricCard
-
-		maxLabelCard := c.MaxLabelCardinality
-		if maxLabelCard == 0 {
-			maxLabelCard = 500 // default
+		if c.MaxLabelCardinality != 0 {
+			if !guardrails.DisallowBlanketRegex {
+				return nil, fmt.Errorf(
+					"max_label_cardinality is set but the %q guardrail is not enabled",
+					prometheus.GuardrailDisallowBlanketRegex)
+			}
+			guardrails.MaxLabelCardinality = c.MaxLabelCardinality
 		}
-		guardrails.MaxLabelCardinality = maxLabelCard
 	}
 
 	return guardrails, nil

--- a/pkg/toolset/config/config_test.go
+++ b/pkg/toolset/config/config_test.go
@@ -184,6 +184,30 @@ max_label_cardinality = 200
 			},
 		},
 		{
+			name: "max_label_cardinality zero sets threshold to zero (always disallow blanket regex)",
+			toml: `
+guardrails = "disallow-blanket-regex"
+max_label_cardinality = 0
+`,
+			wantGuardrails: &prometheus.Guardrails{
+				DisallowBlanketRegex: true,
+				MaxMetricCardinality: prometheus.DefaultMaxMetricCardinality,
+				MaxLabelCardinality:  0,
+			},
+		},
+		{
+			name: "max_metric_cardinality zero sets threshold to zero",
+			toml: `
+guardrails = "max-metric-cardinality"
+max_metric_cardinality = 0
+`,
+			wantGuardrails: &prometheus.Guardrails{
+				ForceMaxMetricCardinality: true,
+				MaxMetricCardinality:      0,
+				MaxLabelCardinality:       prometheus.DefaultMaxLabelCardinality,
+			},
+		},
+		{
 			name: "max_metric_cardinality without enabling the guardrail returns error",
 			toml: `
 guardrails = "require-label-matcher"

--- a/pkg/toolset/config/config_test.go
+++ b/pkg/toolset/config/config_test.go
@@ -41,14 +41,7 @@ func TestValidate(t *testing.T) {
 			toml:    `auth_mode = "magic"`,
 			wantErr: `invalid auth_mode`,
 		},
-		{
-			name: "guardrails all is valid",
-			toml: `guardrails = "all"`,
-		},
-		{
-			name: "guardrails none is valid",
-			toml: `guardrails = "none"`,
-		},
+		// test just a sub set of guardrails validations, the rest is covered in `TestGetGuardrails`
 		{
 			name: "guardrails named list is valid",
 			toml: `guardrails = "require-label-matcher,disallow-blanket-regex"`,
@@ -56,7 +49,15 @@ func TestValidate(t *testing.T) {
 		{
 			name:    "unknown guardrail name returns error",
 			toml:    `guardrails = "not-a-real-guardrail"`,
-			wantErr: `invalid guardrails configuration`,
+			wantErr: `unknown guardrail`,
+		},
+		{
+			name: "max_metric_cardinality without enabling the guardrail returns error",
+			toml: `
+guardrails = "require-label-matcher"
+max_metric_cardinality = 5000
+`,
+			wantErr: "max_metric_cardinality is set but",
 		},
 		{
 			name: "full valid config",
@@ -65,7 +66,7 @@ auth_mode = "kubeconfig"
 prometheus_url = "https://thanos.example.com"
 alertmanager_url = "https://alertmanager.example.com"
 insecure = true
-guardrails = "require-label-matcher,disallow-blanket-regex"
+guardrails = "all"
 max_metric_cardinality = 5000
 max_label_cardinality = 200
 `,

--- a/pkg/toolset/config/config_test.go
+++ b/pkg/toolset/config/config_test.go
@@ -197,16 +197,12 @@ max_label_cardinality = 0
 			},
 		},
 		{
-			name: "max_metric_cardinality zero sets threshold to zero",
+			name: "max_metric_cardinality zero returns error",
 			toml: `
 guardrails = "max-metric-cardinality"
 max_metric_cardinality = 0
 `,
-			wantGuardrails: &prometheus.Guardrails{
-				ForceMaxMetricCardinality: true,
-				MaxMetricCardinality:      0,
-				MaxLabelCardinality:       prometheus.DefaultMaxLabelCardinality,
-			},
+			wantErr: "max_metric_cardinality = 0 is not supported to disable the guardrail",
 		},
 		{
 			name: "guardrails none with max_metric_cardinality returns error",

--- a/pkg/toolset/config/config_test.go
+++ b/pkg/toolset/config/config_test.go
@@ -1,0 +1,254 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+
+	"github.com/rhobs/obs-mcp/pkg/prometheus"
+)
+
+func parseConfig(t *testing.T, tomlStr string) *Config {
+	t.Helper()
+	var cfg Config
+	if _, err := toml.Decode(tomlStr, &cfg); err != nil {
+		t.Fatalf("failed to parse TOML: %v", err)
+	}
+	return &cfg
+}
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		toml    string
+		wantErr string // substring of the expected error; empty means no error
+	}{
+		{
+			name: "empty config is valid",
+			toml: ``,
+		},
+		{
+			name: "auth_mode header is valid",
+			toml: `auth_mode = "header"`,
+		},
+		{
+			name: "auth_mode kubeconfig is valid",
+			toml: `auth_mode = "kubeconfig"`,
+		},
+		{
+			name:    "unknown auth_mode returns error",
+			toml:    `auth_mode = "magic"`,
+			wantErr: `invalid auth_mode`,
+		},
+		{
+			name: "guardrails all is valid",
+			toml: `guardrails = "all"`,
+		},
+		{
+			name: "guardrails none is valid",
+			toml: `guardrails = "none"`,
+		},
+		{
+			name: "guardrails named list is valid",
+			toml: `guardrails = "require-label-matcher,disallow-blanket-regex"`,
+		},
+		{
+			name:    "unknown guardrail name returns error",
+			toml:    `guardrails = "not-a-real-guardrail"`,
+			wantErr: `invalid guardrails configuration`,
+		},
+		{
+			name: "full valid config",
+			toml: `
+auth_mode = "kubeconfig"
+prometheus_url = "https://thanos.example.com"
+alertmanager_url = "https://alertmanager.example.com"
+insecure = true
+guardrails = "require-label-matcher,disallow-blanket-regex"
+max_metric_cardinality = 5000
+max_label_cardinality = 200
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := parseConfig(t, tt.toml)
+			err := cfg.Validate()
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("Validate() unexpected error: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("Validate() expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("Validate() error = %q, want it to contain %q", err.Error(), tt.wantErr)
+				}
+			}
+		})
+	}
+}
+
+func TestGetAuthMode(t *testing.T) {
+	tests := []struct {
+		name string
+		toml string
+		want AuthMode
+	}{
+		{
+			name: "empty auth_mode defaults to header",
+			toml: ``,
+			want: AuthModeHeader,
+		},
+		{
+			name: "auth_mode header returns header",
+			toml: `auth_mode = "header"`,
+			want: AuthModeHeader,
+		},
+		{
+			name: "auth_mode kubeconfig returns kubeconfig",
+			toml: `auth_mode = "kubeconfig"`,
+			want: AuthModeKubeConfig,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := parseConfig(t, tt.toml)
+			got := cfg.GetAuthMode()
+			if got != tt.want {
+				t.Errorf("GetAuthMode() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetGuardrails(t *testing.T) {
+	tests := []struct {
+		name           string
+		toml           string
+		wantErr        string
+		wantNil        bool
+		wantGuardrails *prometheus.Guardrails
+	}{
+		{
+			name:           "empty config returns all guardrails enabled with defaults",
+			toml:           ``,
+			wantGuardrails: prometheus.DefaultGuardrails(true),
+		},
+		{
+			name:           "guardrails all returns all enabled",
+			toml:           `guardrails = "all"`,
+			wantGuardrails: prometheus.DefaultGuardrails(true),
+		},
+		{
+			name:    "guardrails none returns nil",
+			toml:    `guardrails = "none"`,
+			wantNil: true,
+		},
+		{
+			name: "named guardrail list enables only listed",
+			toml: `guardrails = "require-label-matcher,disallow-blanket-regex"`,
+			wantGuardrails: &prometheus.Guardrails{
+				RequireLabelMatcher:  true,
+				DisallowBlanketRegex: true,
+				MaxMetricCardinality: prometheus.DefaultMaxMetricCardinality,
+				MaxLabelCardinality:  prometheus.DefaultMaxLabelCardinality,
+			},
+		},
+		{
+			name: "max_metric_cardinality overrides default when guardrail is enabled",
+			toml: `
+guardrails = "max-metric-cardinality"
+max_metric_cardinality = 5000
+`,
+			wantGuardrails: &prometheus.Guardrails{
+				ForceMaxMetricCardinality: true,
+				MaxMetricCardinality:      5000,
+				MaxLabelCardinality:       prometheus.DefaultMaxLabelCardinality,
+			},
+		},
+		{
+			name: "max_label_cardinality overrides default when disallow-blanket-regex is enabled",
+			toml: `
+guardrails = "disallow-blanket-regex"
+max_label_cardinality = 200
+`,
+			wantGuardrails: &prometheus.Guardrails{
+				DisallowBlanketRegex: true,
+				MaxMetricCardinality: prometheus.DefaultMaxMetricCardinality,
+				MaxLabelCardinality:  200,
+			},
+		},
+		{
+			name: "max_metric_cardinality without enabling the guardrail returns error",
+			toml: `
+guardrails = "require-label-matcher"
+max_metric_cardinality = 5000
+`,
+			wantErr: "max_metric_cardinality is set but",
+		},
+		{
+			name: "max_label_cardinality without disallow-blanket-regex returns error",
+			toml: `
+guardrails = "require-label-matcher"
+max_label_cardinality = 200
+`,
+			wantErr: "max_label_cardinality is set but",
+		},
+		{
+			name: "all guardrails with custom cardinalities",
+			toml: `
+guardrails = "all"
+max_metric_cardinality = 10000
+max_label_cardinality = 300
+`,
+			wantGuardrails: &prometheus.Guardrails{
+				DisallowExplicitNameLabel: true,
+				RequireLabelMatcher:       true,
+				DisallowBlanketRegex:      true,
+				ForceMaxMetricCardinality: true,
+				MaxMetricCardinality:      10000,
+				MaxLabelCardinality:       300,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := parseConfig(t, tt.toml)
+			got, err := cfg.GetGuardrails()
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("GetGuardrails() expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("GetGuardrails() error = %q, want it to contain %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("GetGuardrails() unexpected error: %v", err)
+			}
+
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("GetGuardrails() = %+v, want nil", got)
+				}
+				return
+			}
+
+			if got == nil {
+				t.Fatalf("GetGuardrails() = nil, want %+v", tt.wantGuardrails)
+			}
+			if *got != *tt.wantGuardrails {
+				t.Errorf("GetGuardrails()\n got  %+v\n want %+v", *got, *tt.wantGuardrails)
+			}
+		})
+	}
+}

--- a/pkg/toolset/config/config_test.go
+++ b/pkg/toolset/config/config_test.go
@@ -208,6 +208,22 @@ max_metric_cardinality = 0
 			},
 		},
 		{
+			name: "guardrails none with max_metric_cardinality returns error",
+			toml: `
+guardrails = "none"
+max_metric_cardinality = 5000
+`,
+			wantErr: "max_metric_cardinality is set but",
+		},
+		{
+			name: "guardrails none with max_label_cardinality returns error",
+			toml: `
+guardrails = "none"
+max_label_cardinality = 200
+`,
+			wantErr: "max_label_cardinality is set but",
+		},
+		{
 			name: "max_metric_cardinality without enabling the guardrail returns error",
 			toml: `
 guardrails = "require-label-matcher"


### PR DESCRIPTION
The PR contains the following changes:

**max-metric-cardinality as a first-class guardrail name**

The max metric cardinality check is now a named guardrail that can be explicitly
included/excluded. A new `ForceMaxMetricCardinality` boolean field on the
Guardrails struct replaces the old "0 = disabled" convention for `MaxMetricCardinality`.
We deprecate the convention, forcing the user to use the new approach. Given this
approach was not working only in standalone mode (openshift-mcp config was replacing 0 with default - addressed as well, see bellow).

**Negative (exclusion) mode for --guardrails**
Guardrails can be now disabled with `!` prefix to enable all but specific guardrails.

```shell
  --guardrails='!require-label-matcher'
```

Positive and negative modes cannot be mixed together.

**!tsdb shortcut**
A new shortcut to disable all TSDB-dependent guardrails

```shell
  # before
  --guardrails=disallow-blanket-regex --guardrails.max-label-cardinality=0
  # after
  --guardrails='!tsdb'
```

**Exported default constants**
DefaultMaxMetricCardinality (20000) and DefaultMaxLabelCardinality (500) are now exported
constants, used consistently across the CLI and config parsing.

**Additional changes in behavior**

- Cardinality flags now require the corresponding guardrail to be active. Setting
--guardrails.max-metric-cardinality when max-metric-cardinality is not in --guardrails, or
--guardrails.max-label-cardinality when disallow-blanket-regex is not active, now produces
a fatal error rather than silently having no effect.
- MaxMetricCardinality / MaxLabelCardinality in the TOML config are now *uint64 (pointer)to distinguish "not set" (use default) from "explicitly set to 0". Setting them when the
corresponding guardrail is not enabled now returns an error.
- The GuardrailMaxLabelCardinality constant ("max-label-cardinality") has been removed;
the guardrail violation now reports under GuardrailDisallowBlanketRegex.

**Additional notes**

This is an alternative approach to https://github.com/rhobs/obs-mcp/pull/70. It also tries to address https://github.com/rhobs/obs-mcp/pull/47 by allowing to set `--guardrails` to `!tsdb`.
