### PR TITLE
docs: restructure release process to use release branches

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,26 +4,88 @@ This document describes how to create a new release of obs-mcp.
 
 ## Prerequisites
 
-- A GPG key configured for signing git tags (`git config user.signingkey`)
+- A GPG key configured for [signing commits and tags](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (`git config user.signingkey`)
 - Push access to the repository
 
-## Steps
+## Branch management and versioning strategy
 
-### 1. Update CHANGELOG.md
+We use [Semantic Versioning](https://semver.org/) and maintain a separate branch for each minor release, named `release-<major>.<minor>` (e.g., `release-0.1`, `release-0.2`).
 
-Ensure main is up to date:
+### Flow
+
+- New features and changes are merged into `main`.
+- When ready to cut a new minor release, create a `release-X.Y` branch from `main`. From this point on, all release work (changelog, tagging) happens on the release branch.
+- Bug fixes for a released version are merged into the **latest release branch**.
+- Bug fixes from the release branch are then merged back into `main` so that `main` always contains all commits from the latest release branch.
+
+```
+main:          A---B---C-----------G
+                        \         /
+release-0.1:             C'--D--fix1--fix2
+                          |        |
+                        v0.1.0   v0.1.1
+```
+
+### Rules
+
+- `main` should always contain all commits from the latest release branch.
+- If a bug fix is accidentally merged into `main` instead of the release branch, cherry-pick the commits into the release branch and merge back into `main`. Avoid this situation when possible.
+- Maintaining release branches for older minor releases happens on a best effort basis.
+
+> [!NOTE]
+> Pushing to a release branch does not trigger the release workflow — only tag pushes (`v*`) trigger it. CI checks (lint, unit tests, e2e) will run as usual.
+
+## How to cut a new release
+
+### New minor release
+
+For a new minor release, work from `main`. For a patch release, see [Patch release](#patch-release).
+
+#### 1. Create the release branch
+
+Ensure `main` is up to date:
 
 ```bash
 git checkout main
 git pull <remote> main --rebase
 ```
 
-Replace `<remote>` with the name of your upstream remote. Verify with `git remote -v`.
+Replace `<remote>` with the name of your upstream remote (i.e., the one pointing to `github.com/rhobs/obs-mcp`). Verify with `git remote -v`.
 
-Create a branch, add a new section following the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format:
+Create the release branch from `main`. You can do this from the GitHub UI (create a new branch from `main` named `release-X.Y`) or from the command line:
 
 ```bash
-git checkout -b release-vX.Y.Z
+git checkout -b release-X.Y
+git push <remote> release-X.Y
+```
+
+From this point on, all release work happens on a branch based off `release-X.Y`.
+
+#### Pre-releases (optional)
+
+Before cutting a stable release, you can optionally tag a release candidate from the release branch to test artifacts and get early feedback. No changelog update is needed for pre-releases — keep the `[Unreleased]` section updated as changes land, and it will be promoted to a versioned section during the stable release.
+
+```bash
+git checkout release-X.Y
+export VERSION=X.Y.Z-rc.N
+export TAG="v${VERSION}"
+make tag VERSION=${VERSION}
+git push <remote> ${TAG}
+```
+
+Pre-releases are marked as "pre-release" on GitHub and won't be considered the "latest" release. Use them to:
+
+- Test release artifacts before a stable release
+- Get feedback from early adopters
+- Verify the release process
+
+#### 2. Update CHANGELOG.md
+
+Create a branch from the release branch, add a new section following the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format:
+
+```bash
+git fetch <remote> release-X.Y
+git checkout -b cut-vX.Y.Z <remote>/release-X.Y
 ```
 
 ```markdown
@@ -43,32 +105,31 @@ Commit and push to your fork:
 
 ```bash
 git add CHANGELOG.md
-git commit -m "docs: update changelog for vX.Y.Z"
-git push <fork> release-vX.Y.Z
+git commit -s -S -m "docs: update changelog for vX.Y.Z"
+git push <fork> cut-vX.Y.Z
 ```
 
-Open a PR from your fork to upstream `main` and merge.
+Open a PR targeting `release-X.Y`, review, and merge.
 
-### 2. Create and push the tag
-
-Pull the merged changelog into main:
+Pull the merged changes to your local release branch:
 
 ```bash
-git checkout main
-git pull <remote> main --rebase
+git checkout release-X.Y
+git pull <remote> release-X.Y --rebase
 ```
 
-Verify tests pass:
+Verify the branch points to the expected commit (the merged changelog PR):
 
 ```bash
-make test-unit
-make lint
+git log --oneline -5
 ```
+
+#### 3. Create and push the tag
 
 Set the version and create a signed tag:
 
 ```bash
-export VERSION=0.1.0
+export VERSION=X.Y.Z
 export TAG="v${VERSION}"
 make tag VERSION=${VERSION}
 ```
@@ -93,7 +154,7 @@ Pushing the tag triggers the [release workflow](.github/workflows/release.yaml),
 - Signs release archives with [cosign](https://docs.sigstore.dev/quickstart/quickstart-ci/) (keyless)
 - Creates a GitHub release with the binaries, checksums, and auto-generated changelog
 
-### 3. Verify the release
+#### 4. Verify the release
 
 - Check the [Actions tab](../../actions/workflows/release.yaml) for the workflow run
 - Confirm the release appears under [Releases](../../releases) with the expected assets:
@@ -104,6 +165,34 @@ Pushing the tag triggers the [release workflow](.github/workflows/release.yaml),
   - `checksums.txt`
   - `.bundle` signature files for each archive
 
+#### 5. Merge back to main
+
+Create a PR to merge the release branch back into `main` to ensure `main` contains the changelog and any release commits:
+
+```bash
+git checkout -b merge-release-X.Y release-X.Y
+git pull <remote> main --rebase
+git push <fork> merge-release-X.Y
+```
+
+Open a PR targeting `main`, review, and merge.
+
+### Patch release
+
+For patch releases, work on the existing release branch:
+
+```bash
+git fetch <remote> release-X.Y
+git checkout -b <bugfix-branch> <remote>/release-X.Y
+# make your fix changes
+git add . && git commit -s -S -m "fix: description of the fix"
+git push <fork> <bugfix-branch>
+```
+
+Open a PR targeting `release-X.Y`, review, and merge.
+
+Then follow the same steps as a new minor release starting from [Update CHANGELOG.md](#2-update-changelogmd) to update the changelog, tag, verify, and merge back to `main`.
+
 ## Manual release (via workflow dispatch)
 
 A release can also be triggered manually from the GitHub Actions UI:
@@ -111,25 +200,6 @@ A release can also be triggered manually from the GitHub Actions UI:
 1. Go to **Actions** > **release** workflow
 2. Click **Run workflow**
 3. Enter the tag (e.g., `v0.1.0`) and run
-
-## Pre-releases
-
-Pre-releases follow the same process as stable releases but use the tag format `vX.Y.Z-rc.N`. No changelog PR is needed at release time keep the `[Unreleased]` section updated as changes land in main, and it will be promoted to a versioned section during the stable release.
-
-```bash
-git checkout main
-git pull <remote> main --rebase
-export VERSION=0.1.0-rc.1
-export TAG="v${VERSION}"
-make tag VERSION=${VERSION}
-git push <remote> ${TAG}
-```
-
-Pre-releases are marked as "pre-release" on GitHub and won't be considered the "latest" release. Use them to:
-
-- Test release artifacts before a stable release
-- Get feedback from early adopters
-- Verify the release process
 
 ## Verifying release signatures
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -177,6 +177,16 @@ git push <fork> merge-release-X.Y
 
 Open a PR targeting `main`, review, and merge.
 
+#### 6. Bump dependency in openshift-mcp-server
+
+After the release is published, open a PR in [openshift-mcp-server](https://github.com/openshift/openshift-mcp-server) to bump the `github.com/rhobs/obs-mcp` dependency to the new version, and cherry-pick to release branches as required:
+
+```bash
+go get github.com/rhobs/obs-mcp@vX.Y.Z
+go mod tidy
+go mod vendor
+```
+
 ### Patch release
 
 For patch releases, work on the existing release branch:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,15 +15,15 @@ We use [Semantic Versioning](https://semver.org/) and maintain a separate branch
 
 - New features and changes are merged into `main`.
 - When ready to cut a new minor release, create a `release-X.Y` branch from `main`. From this point on, all release work (changelog, tagging) happens on the release branch.
-- Bug fixes for a released version are merged into the **latest release branch**.
+- Bug fixes for a released version are merged into the **latest maintained release branch** (the `release-X.Y` branch with the highest `Y` for the current `X`).
 - Bug fixes from the release branch are then merged back into `main` so that `main` always contains all commits from the latest release branch.
 
-```
+```text
 main:          A---B---C-----------G
                         \         /
-release-0.1:             C'--D--fix1--fix2
+release-X.Y:             C'--D--fix1--fix2
                           |        |
-                        v0.1.0   v0.1.1
+                        vX.Y.0   vX.Y.1
 ```
 
 ### Rules


### PR DESCRIPTION
Now that we have stable release v0.1.3 🤞🏻 so I have created release branch https://github.com/rhobs/obs-mcp/tree/release-0.1
 
This PR update release model where the release branch is created first and all release work (changelog, tagging) happens from it for next releases to manage releases better way