### PR TITLE
chore: disable coderabbit docstrings coverage

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -10,6 +10,9 @@ reviews:
   collapse_walkthrough: true
   changed_files_summary: false
   poem: false
+  pre_merge_checks:
+    docstrings:
+      mode: off
   path_instructions:
     - path: '**'
       instructions: >-


### PR DESCRIPTION
In https://github.com/rhobs/obs-mcp/pull/86, the check fails on docstring coverage (9% vs. 80%). It seems it's counting test functions in the calculation and I fail to see how it would be helping the codebase.