### PR TITLE
NO-JIRA: rename CLI arg -tempo.use-route to -traces.use-route

### DIFF
--- a/cmd/obs-mcp/main.go
+++ b/cmd/obs-mcp/main.go
@@ -54,7 +54,7 @@ func main() {
 		"Maximum allowed label value count for blanket regex (0 = always disallow blanket regex).\n"+
 			"Only takes effect if disallow-blanket-regex is enabled.")
 	var fullRangeQueryResponse = flag.Bool("full-range-query-response", false, "Return full data points for range queries")
-	var tempoUseRoute = flag.Bool("tempo.use-route", false, "Use Route instead of internal service DNS when connecting to Tempo API")
+	var tracesUseRoute = flag.Bool("traces.use-route", false, "Use Route instead of internal service DNS when connecting to Tempo API")
 	flag.Parse()
 
 	if *showVersion {
@@ -139,10 +139,10 @@ func main() {
 		Insecure:               *insecure,
 		Guardrails:             parsedGuardrails,
 		FullRangeQueryResponse: *fullRangeQueryResponse,
-		Tempo: &traces.Config{
+		Traces: &traces.Config{
 			AuthMode: config.AuthMode(parsedAuthMode),
 			Insecure: *insecure,
-			UseRoute: *tempoUseRoute,
+			UseRoute: *tracesUseRoute,
 		},
 		Otelcol: otelcol.NewDefaultConfig(),
 	}

--- a/hack/tempo_multitenancy_openshift/04_tempo.yaml
+++ b/hack/tempo_multitenancy_openshift/04_tempo.yaml
@@ -24,6 +24,8 @@ spec:
   template:
     gateway:
       enabled: true
+      ingress:
+        type: route
     queryFrontend:
       jaegerQuery:
         enabled: true

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -42,7 +42,7 @@ type ObsMCPOptions struct {
 	Insecure               bool
 	Guardrails             *prometheus.Guardrails
 	FullRangeQueryResponse bool
-	Tempo                  *traces.Config
+	Traces                 *traces.Config
 	Otelcol                *otelcol.Config
 }
 
@@ -98,7 +98,7 @@ func SetupTools(mcpServer *mcp.Server, opts ObsMCPOptions) error {
 	}
 
 	if slices.Contains(opts.Toolsets, ToolsetTraces) {
-		if opts.Tempo == nil {
+		if opts.Traces == nil {
 			return errors.New("configuration for traces toolset is missing")
 		}
 
@@ -114,11 +114,11 @@ func SetupTools(mcpServer *mcp.Server, opts ObsMCPOptions) error {
 		if err != nil {
 			return err
 		}
-		mcp.AddTool(mcpServer, traces.ListInstancesTool.ToMCPTool(), traces.ToMCPHandler(newTempoClient, dynamicClient, opts.Tempo, tempoToolset.ListInstancesHandler))
-		mcp.AddTool(mcpServer, traces.GetTraceByIDTool.ToMCPTool(), traces.ToMCPHandler(newTempoClient, dynamicClient, opts.Tempo, tempoToolset.GetTraceByIDHandler))
-		mcp.AddTool(mcpServer, traces.SearchTracesTool.ToMCPTool(), traces.ToMCPHandler(newTempoClient, dynamicClient, opts.Tempo, tempoToolset.SearchTracesHandler))
-		mcp.AddTool(mcpServer, traces.SearchTagsTool.ToMCPTool(), traces.ToMCPHandler(newTempoClient, dynamicClient, opts.Tempo, tempoToolset.SearchTagsHandler))
-		mcp.AddTool(mcpServer, traces.SearchTagValuesTool.ToMCPTool(), traces.ToMCPHandler(newTempoClient, dynamicClient, opts.Tempo, tempoToolset.SearchTagValuesHandler))
+		mcp.AddTool(mcpServer, traces.ListInstancesTool.ToMCPTool(), traces.ToMCPHandler(newTempoClient, dynamicClient, opts.Traces, tempoToolset.ListInstancesHandler))
+		mcp.AddTool(mcpServer, traces.GetTraceByIDTool.ToMCPTool(), traces.ToMCPHandler(newTempoClient, dynamicClient, opts.Traces, tempoToolset.GetTraceByIDHandler))
+		mcp.AddTool(mcpServer, traces.SearchTracesTool.ToMCPTool(), traces.ToMCPHandler(newTempoClient, dynamicClient, opts.Traces, tempoToolset.SearchTracesHandler))
+		mcp.AddTool(mcpServer, traces.SearchTagsTool.ToMCPTool(), traces.ToMCPHandler(newTempoClient, dynamicClient, opts.Traces, tempoToolset.SearchTagsHandler))
+		mcp.AddTool(mcpServer, traces.SearchTagValuesTool.ToMCPTool(), traces.ToMCPHandler(newTempoClient, dynamicClient, opts.Traces, tempoToolset.SearchTagValuesHandler))
 	}
 
 	if slices.Contains(opts.Toolsets, ToolsetOtelcol) {


### PR DESCRIPTION
Rename CLI arg `-tempo.use-route` to `-traces.use-route` to be in sync with the toolset name.