### PR TITLE
test: add smoke test for otelcol toolset

### DIFF
--- a/manifests/kubernetes/03_deployment.yaml
+++ b/manifests/kubernetes/03_deployment.yaml
@@ -30,7 +30,7 @@ spec:
             - --log-level
             - debug
             - --toolsets
-            - metrics,traces
+            - metrics,traces,otelcol
           env:
             - name: PROMETHEUS_URL
               valueFrom:

--- a/manifests/openshift_e2e/03_deployment.yaml
+++ b/manifests/openshift_e2e/03_deployment.yaml
@@ -33,7 +33,7 @@ spec:
             - --log-level
             - debug
             - --toolsets
-            - metrics,traces
+            - metrics,traces,otelcol
           env:
             - name: PROMETHEUS_URL
               valueFrom:

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -923,3 +923,7 @@ func TestTempoSearchTagValues_MissingTag(t *testing.T) {
 	}
 	t.Error("Expected isError:true for missing tag parameter")
 }
+
+func TestOtelcolToolset(t *testing.T) {
+	runOtelcolToolsetTests(t, mcpClient)
+}

--- a/tests/e2e/openshift_e2e_test.go
+++ b/tests/e2e/openshift_e2e_test.go
@@ -132,3 +132,11 @@ func TestOpenShiftMetricsPresent(t *testing.T) {
 	}
 	t.Logf("OpenShift metric %q confirmed present", metric)
 }
+
+func TestOtelcolToolset(t *testing.T) {
+	mcpURL := os.Getenv("OBS_MCP_URL")
+	if mcpURL == "" {
+		t.Skip("OBS_MCP_URL not set; skipping (set OBS_MCP_URL to run against a deployed or local obs-mcp)")
+	}
+	runOtelcolToolsetTests(t, NewMCPClient(mcpURL))
+}

--- a/tests/e2e/otelcol_e2e_test.go
+++ b/tests/e2e/otelcol_e2e_test.go
@@ -1,0 +1,28 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// runOtelcolToolsetTests verifies the otelcol toolset is registered on the deployed server.
+// Schema and validation logic are covered by unit tests in pkg/otelcol.
+func runOtelcolToolsetTests(t *testing.T, client *MCPClient) {
+	t.Helper()
+
+	resp, err := client.CallTool(t, 47, "otelcol_get_versions", map[string]any{})
+	if err != nil {
+		t.Fatalf("Failed to call otelcol_get_versions: %v", err)
+	}
+	if resp.Error != nil {
+		t.Fatalf("MCP error: %s", resp.Error.Message)
+	}
+
+	structured, ok := resp.Result["structuredContent"].(map[string]any)
+	require.True(t, ok, "expected structuredContent in result")
+	require.NotEmpty(t, structured["versions"])
+	require.NotEmpty(t, structured["latest_version"])
+}


### PR DESCRIPTION
Enable otelcol in Kind and OpenShift e2e deployments and verify MCP tools are registered and callable end-to-end.