### PR TITLE
evals: add  label to traces and otelcol tasks

### DIFF
--- a/evals/mcpchecker/tasks/otelcol/get-batch-processor-schema.yaml
+++ b/evals/mcpchecker/tasks/otelcol/get-batch-processor-schema.yaml
@@ -7,6 +7,7 @@ metadata:
   runs: 1
   labels:
     category: otelcol
+    suite: observability
     toolType: schema
   description: |
     Tests if the agent can retrieve the schema for the batch processor.

--- a/evals/mcpchecker/tasks/otelcol/get-versions.yaml
+++ b/evals/mcpchecker/tasks/otelcol/get-versions.yaml
@@ -7,6 +7,7 @@ metadata:
   runs: 1
   labels:
     category: otelcol
+    suite: observability
     toolType: versions
   description: |
     Tests if the agent can list available OpenTelemetry Collector versions.

--- a/evals/mcpchecker/tasks/otelcol/list-components.yaml
+++ b/evals/mcpchecker/tasks/otelcol/list-components.yaml
@@ -7,6 +7,7 @@ metadata:
   runs: 1
   labels:
     category: otelcol
+    suite: observability
     toolType: components
   description: |
     Tests if the agent can list available OpenTelemetry Collector components.

--- a/evals/mcpchecker/tasks/otelcol/validate-batch-processor-config-invalid.yaml
+++ b/evals/mcpchecker/tasks/otelcol/validate-batch-processor-config-invalid.yaml
@@ -7,6 +7,7 @@ metadata:
   runs: 1
   labels:
     category: otelcol
+    suite: observability
     toolType: validation
   description: |
     Tests if the agent can detect an invalid batch processor configuration.

--- a/evals/mcpchecker/tasks/otelcol/validate-batch-processor-config-valid.yaml
+++ b/evals/mcpchecker/tasks/otelcol/validate-batch-processor-config-valid.yaml
@@ -7,6 +7,7 @@ metadata:
   runs: 1
   labels:
     category: otelcol
+    suite: observability
     toolType: validation
   description: |
     Tests if the agent can validate a valid batch processor configuration.

--- a/evals/mcpchecker/tasks/traces/latency-investigation.yaml
+++ b/evals/mcpchecker/tasks/traces/latency-investigation.yaml
@@ -7,6 +7,7 @@ metadata:
   runs: 1
   labels:
     category: traces
+    suite: observability
     toolType: query
   description: |
     Tests if the agent can find high latency traces for a specific service

--- a/evals/mcpchecker/tasks/traces/search-error-traces.yaml
+++ b/evals/mcpchecker/tasks/traces/search-error-traces.yaml
@@ -7,6 +7,7 @@ metadata:
   runs: 1
   labels:
     category: traces
+    suite: observability
     toolType: query
   description: |
     Tests if the agent can discover Tempo instances and search for


### PR DESCRIPTION
Align otelcol and traces MCPChecker tasks with the observability suite label used by other eval tasks for filtering and openshift-mcp-server sync.