### PR TITLE
Improve dev exeprience when running local process against cluster backends

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ test-e2e-pf: ## Port-forward obs-mcp e2e deployment locally
 
 .PHONY: test-e2e-run
 test-e2e-run: ## Run obs-mcp locally against the E2E cluster (auto port-forwards)
-   ./hack/e2e/setup.sh run --profile $(E2E_PROFILE) --stacks $(E2E_STACKS)
+	./hack/e2e/setup.sh run --profile $(E2E_PROFILE) --stacks $(E2E_STACKS)
 
 .PHONY: test-e2e-teardown
 test-e2e-teardown: ## Teardown E2E test cluster

--- a/Makefile
+++ b/Makefile
@@ -168,13 +168,15 @@ export CONTAINER_CLI
 export IMAGE_REF
 
 E2E_PROFILE ?= kind
+E2E_STACKS ?= prometheus,tempo,loki
+
 .PHONY: test-e2e-setup
 test-e2e-setup: ## Setup the cluster for E2E tests
-	./hack/e2e/setup.sh $(if $(filter kind,$(E2E_PROFILE)),provision) prereqs extras --profile $(E2E_PROFILE)
+	./hack/e2e/setup.sh $(if $(filter kind,$(E2E_PROFILE)),provision) prereqs extras --profile $(E2E_PROFILE) --stacks $(E2E_STACKS)
 
 .PHONY: test-e2e-deploy
 test-e2e-deploy: container ## Build and deploy obs-mcp to the cluster
-	./hack/e2e/setup.sh upload deploy --profile $(E2E_PROFILE)
+	./hack/e2e/setup.sh upload deploy --profile $(E2E_PROFILE) --stacks $(E2E_STACKS)
 
 .PHONY: test-e2e
 test-e2e: ## Run E2E tests (requires cluster to be running)
@@ -184,9 +186,13 @@ test-e2e: ## Run E2E tests (requires cluster to be running)
 test-e2e-pf: ## Port-forward obs-mcp e2e deployment locally
 	kubectl port-forward -n obs-mcp svc/obs-mcp 9100:9100
 
+.PHONY: test-e2e-run
+test-e2e-run: ## Run obs-mcp locally against the E2E cluster (auto port-forwards)
+   ./hack/e2e/setup.sh run --profile $(E2E_PROFILE) --stacks $(E2E_STACKS)
+
 .PHONY: test-e2e-teardown
 test-e2e-teardown: ## Teardown E2E test cluster
-	./hack/e2e/setup.sh down --profile $(E2E_PROFILE)
+	./hack/e2e/setup.sh down --profile $(E2E_PROFILE) --stacks $(E2E_STACKS)
 
 .PHONY: test-e2e-full
 test-e2e-full: test-e2e-setup test-e2e-deploy test-e2e test-e2e-teardown ## Run full E2E test cycle (setup, test, teardown)
@@ -198,7 +204,7 @@ test-e2e-full: test-e2e-setup test-e2e-deploy test-e2e test-e2e-teardown ## Run 
 .PHONY: test-e2e-openshift-deploy
 test-e2e-openshift-deploy: ## Deploy obs-mcp to OpenShift (uses IMAGE env var from CI)
 	# We use IMAGE until we update the CI job to pass IMAGE_REF instead.
-	IMAGE_REF="$(IMAGE)" ./hack/e2e/setup.sh prereqs extras deploy --profile openshift
+	IMAGE_REF="$(IMAGE)" ./hack/e2e/setup.sh prereqs extras deploy --profile openshift --stacks $(E2E_STACKS)
 
 .PHONY: test-e2e-openshift
 test-e2e-openshift: ## Run OpenShift route discovery E2E tests (requires oc login)

--- a/cmd/obs-mcp/main.go
+++ b/cmd/obs-mcp/main.go
@@ -55,6 +55,7 @@ func main() {
 		"Maximum allowed label value count for blanket regex (0 = always disallow blanket regex).\n"+
 			"Only takes effect if disallow-blanket-regex is enabled.")
 	var fullRangeQueryResponse = flag.Bool("full-range-query-response", false, "Return full data points for range queries")
+	var tempoURL = flag.String("traces.tempo-url", "", "Tempo API base URL (overrides TEMPO_URL when explicitly set)")
 	var tracesUseRoute = flag.Bool("traces.use-route", false, "Use Route instead of internal service DNS when connecting to Tempo API")
 	var lokiURL = flag.String("loki-url", "", "Loki API base URL (overrides LOKI_URL when explicitly set)")
 	var lokiUseRoute = flag.Bool("loki.use-route", false, "Use OpenShift Routes when discovering LokiStack endpoints")
@@ -150,6 +151,13 @@ func main() {
 		}
 	}
 
+	// Determine Tempo URL only when traces toolset is enabled.
+	tempoResolvedURL := ""
+	tempoURLSource := ""
+	if slices.Contains(parsedToolsets, mcpserver.ToolsetTraces) {
+		tempoResolvedURL, tempoURLSource = determineTempoURL(*tempoURL)
+	}
+
 	// Create MCP options
 	opts := mcpserver.ObsMCPOptions{
 		Toolsets:               parsedToolsets,
@@ -163,6 +171,7 @@ func main() {
 		Traces: &traces.Config{
 			AuthMode: parsedAuthMode,
 			Insecure: *insecure,
+			TempoURL: tempoResolvedURL,
 			UseRoute: *tracesUseRoute,
 		},
 		Otelcol:      otelcol.NewDefaultConfig(),
@@ -184,6 +193,8 @@ func main() {
 		"alertmanager_url_source", alertmanagerURLSource,
 		"loki_url", opts.LokiURL,
 		"loki_url_source", lokiURLSource,
+		"tempo_url", tempoResolvedURL,
+		"tempo_url_source", tempoURLSource,
 		"guardrails", opts.Guardrails,
 	)
 
@@ -276,6 +287,17 @@ func determineAlertmanagerURL(authMode auth.AuthMode) (url, source string, err e
 			"  Set it via environment variable or use --auth-mode kubeconfig for auto-discovery",
 		authMode,
 	)
+}
+
+func determineTempoURL(flagURL string) (url, source string) {
+	if flagURL != "" {
+		return flagURL, "--traces.tempo-url flag"
+	}
+	if tempoURL := os.Getenv("TEMPO_URL"); tempoURL != "" {
+		return tempoURL, "TEMPO_URL env var"
+	}
+	slog.Info("No Tempo URL configured; Tempo tools require tempoNamespace+tempoName discovery parameters or explicit Tempo URL")
+	return "", "unset"
 }
 
 func determineLokiURL(authMode auth.AuthMode, flagURL string, useRoute bool) (url, source string, err error) {

--- a/cmd/obs-mcp/main.go
+++ b/cmd/obs-mcp/main.go
@@ -110,7 +110,7 @@ func main() {
 	lokiResolvedURL := ""
 	lokiURLSource := ""
 	if slices.Contains(parsedToolsets, mcpserver.ToolsetLogs) {
-		lokiResolvedURL, lokiURLSource, err = determineLokiURL(parsedAuthMode, *lokiURL)
+		lokiResolvedURL, lokiURLSource, err = determineLokiURL(parsedAuthMode, *lokiURL, *lokiUseRoute)
 		if err != nil {
 			log.Fatalf("%v", err)
 		}
@@ -278,14 +278,14 @@ func determineAlertmanagerURL(authMode auth.AuthMode) (url, source string, err e
 	)
 }
 
-func determineLokiURL(authMode auth.AuthMode, flagURL string) (url, source string, err error) {
+func determineLokiURL(authMode auth.AuthMode, flagURL string, useRoute bool) (url, source string, err error) {
 	if flagURL != "" {
 		return flagURL, "--loki-url flag", nil
 	}
 	if lokiURL := os.Getenv("LOKI_URL"); lokiURL != "" {
 		return lokiURL, "LOKI_URL env var", nil
 	}
-	if authMode == auth.AuthModeKubeConfig {
+	if authMode == auth.AuthModeKubeConfig && !useRoute {
 		slog.Warn("No Loki URL configured, falling back to default", "default", defaultLokiURL)
 		return defaultLokiURL, "default", nil
 	}

--- a/cmd/obs-mcp/main_test.go
+++ b/cmd/obs-mcp/main_test.go
@@ -148,7 +148,7 @@ func TestDetermineMetricsBackendURL_EnvVarOverridesAll(t *testing.T) {
 func TestDetermineLokiURL(t *testing.T) {
 	t.Run("explicit flag wins", func(t *testing.T) {
 		t.Setenv("LOKI_URL", "http://from-env:3100")
-		got, source, err := determineLokiURL(auth.AuthModeHeader, "http://from-flag:3100")
+		got, source, err := determineLokiURL(auth.AuthModeHeader, "http://from-flag:3100", false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -159,7 +159,7 @@ func TestDetermineLokiURL(t *testing.T) {
 
 	t.Run("env used when flag missing", func(t *testing.T) {
 		t.Setenv("LOKI_URL", "http://from-env:3100")
-		got, source, err := determineLokiURL(auth.AuthModeHeader, "")
+		got, source, err := determineLokiURL(auth.AuthModeHeader, "", false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -170,7 +170,7 @@ func TestDetermineLokiURL(t *testing.T) {
 
 	t.Run("kubeconfig falls back to default", func(t *testing.T) {
 		t.Setenv("LOKI_URL", "")
-		got, source, err := determineLokiURL(auth.AuthModeKubeConfig, "")
+		got, source, err := determineLokiURL(auth.AuthModeKubeConfig, "", false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -181,10 +181,36 @@ func TestDetermineLokiURL(t *testing.T) {
 
 	t.Run("non-kubeconfig without URL returns unset", func(t *testing.T) {
 		t.Setenv("LOKI_URL", "")
-		got, source, err := determineLokiURL(auth.AuthModeHeader, "")
+		got, source, err := determineLokiURL(auth.AuthModeHeader, "", false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
+		if got != "" || source != "unset" {
+			t.Fatalf("unexpected result: %s (%s)", got, source)
+		}
+	})
+}
+
+func TestDetermineTempoURL(t *testing.T) {
+	t.Run("explicit flag wins", func(t *testing.T) {
+		t.Setenv("TEMPO_URL", "http://from-env:3200")
+		got, source := determineTempoURL("http://from-flag:3200")
+		if got != "http://from-flag:3200" || source != "--traces.tempo-url flag" {
+			t.Fatalf("unexpected result: %s (%s)", got, source)
+		}
+	})
+
+	t.Run("env used when flag missing", func(t *testing.T) {
+		t.Setenv("TEMPO_URL", "http://from-env:3200")
+		got, source := determineTempoURL("")
+		if got != "http://from-env:3200" || source != "TEMPO_URL env var" {
+			t.Fatalf("unexpected result: %s (%s)", got, source)
+		}
+	})
+
+	t.Run("no URL returns unset", func(t *testing.T) {
+		t.Setenv("TEMPO_URL", "")
+		got, source := determineTempoURL("")
 		if got != "" || source != "unset" {
 			t.Fatalf("unexpected result: %s (%s)", got, source)
 		}

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -23,7 +23,19 @@ To use the remote deployment locally, you can port-forward the MCP service with
 make test-e2e-pf
 ```
 
-These make targets leverage the `setup.sh` script. See [using setup.sh](#using-setup.sh) below for more details.
+These make targets leverage the `setup.sh` script. See [using setup.sh](#using-setupsh) below for more details.
+
+### Running locally
+
+To run the server locally against the backends from the cluster:
+
+```
+E2E_PROFILE=kind  # or openshift
+make test-e2e-run
+```
+
+This command will open all necessary port-forwards to the backends running in
+the test cluster.
 
 ## Authentication Modes
 

--- a/hack/e2e/setup.sh
+++ b/hack/e2e/setup.sh
@@ -27,6 +27,15 @@ _wait_rollout() {
     _run $KUBECTL -n "${namespace}" rollout status "${resource}" --timeout="${timeout}"
 }
 
+# Kill background port-forward processes.
+# Usage: _cleanup_pf PID [PID ...]
+_cleanup_pf() {
+    step "Clean up port-forward processes"
+    for pid in "$@"; do
+        kill "$pid" 2>/dev/null || true
+    done
+}
+
 # Execute the command while capturing the output. Print the output to stderr on fail.
 _run() {
     local _out
@@ -60,7 +69,7 @@ _relativepath() {
 PHASE_DEFAULT="up"
 PROFILE="kind"
 STACKS="prometheus,tempo,loki"
-SUPPORTED_PHASES=(provision prereqs extras upload deploy clean unprovision)
+SUPPORTED_PHASES=(provision prereqs extras upload deploy run clean unprovision)
 SUPPORTED_PROFILES=(kind k8s openshift)
 SUPPORTED_STACKS=(prometheus tempo loki)
 
@@ -533,6 +542,94 @@ EOF
     _wait_rollout obs-mcp deployment/obs-mcp 3m
 }
 
+phase_run() {
+    phase "run"
+
+    step "Building obs-mcp"
+    _run go build -mod=mod -o "${ROOT_DIR}/obs-mcp" ./cmd/obs-mcp
+
+    # Collect background port-forward PIDs for cleanup on exit.
+    local _pf_pids=()
+    trap '_cleanup_pf "${_pf_pids[@]}"' EXIT INT TERM
+
+    local _env_vars=()
+    local _flags=(
+        --listen ":9100"
+        --auth-mode kubeconfig
+        --insecure
+        --log-level debug
+    )
+
+    # Toolsets — always include otelcol.
+    local _toolsets_parts=(otelcol)
+
+    # -- Prometheus & Alertmanager --
+    if has_stack prometheus; then
+        _toolsets_parts+=(metrics)
+        case ${PROFILE} in
+            openshift)
+                step "Port-forwarding Prometheus (openshift-monitoring)"
+                $KUBECTL port-forward -n openshift-monitoring pod/prometheus-k8s-0 9090:9090 &
+                _pf_pids+=($!)
+                step "Port-forwarding Alertmanager (openshift-monitoring)"
+                $KUBECTL port-forward -n openshift-monitoring pod/alertmanager-main-0 9093:9093 &
+                _pf_pids+=($!)
+                ;;
+            *)
+                step "Port-forwarding Prometheus (monitoring)"
+                $KUBECTL port-forward -n monitoring svc/prometheus-k8s 9090:9090 &
+                _pf_pids+=($!)
+                step "Port-forwarding Alertmanager (monitoring)"
+                $KUBECTL port-forward -n monitoring svc/alertmanager-main 9093:9093 &
+                _pf_pids+=($!)
+                ;;
+        esac
+        _env_vars+=(PROMETHEUS_URL=http://localhost:9090 ALERTMANAGER_URL=http://localhost:9093)
+    fi
+
+    # -- Tempo --
+    if has_stack tempo; then
+        case ${PROFILE} in
+            openshift)
+                _toolsets_parts+=(traces)
+                _flags+=(--traces.use-route)
+                ;;
+            *)
+                fail "Tempo requires OpenShift routes for local run (no --tempo-url flag). Disable the tempo stack or run with --profile openshift."
+                ;;
+        esac
+    fi
+
+    # -- Loki --
+    if has_stack loki; then
+        _toolsets_parts+=(logs)
+        case ${PROFILE} in
+            openshift)
+                _flags+=(--loki.use-route)
+                ;;
+            *)
+                step "Port-forwarding Loki gateway (obs-mcp-loki)"
+                $KUBECTL port-forward -n obs-mcp-loki svc/obs-mcp-loki-gateway-http 8080:8080 &
+                _pf_pids+=($!)
+                _flags+=(--loki-url http://localhost:8080)
+                ;;
+        esac
+    fi
+
+    _flags+=(--toolsets "$(IFS=,; echo "${_toolsets_parts[*]}")") 
+
+    # Give port-forwards a moment to bind.
+    if [[ ${#_pf_pids[@]} -gt 0 ]]; then
+        sleep 2
+    fi
+
+    step "Starting obs-mcp"
+    info "Flags: ${_flags[*]}"
+    info "Env:   ${_env_vars[*]}"
+
+    env "${_env_vars[@]}" "${ROOT_DIR}/obs-mcp" "${_flags[@]}"
+}
+
 phase_clean() {
     phase "clean"
     # TODO: remove temporary files (e.g. tmp/kube-prometheus)
@@ -566,6 +663,7 @@ for phase in "${PHASES[@]}"; do
         extras)      phase_extras ;;
         upload)      phase_upload ;;
         deploy)      phase_deploy ;;
+        run)         phase_run ;;
         clean)       phase_clean ;;
         unprovision) phase_unprovision ;;
         *)           fail "Unknown phase: ${phase}" ;;

--- a/hack/e2e/setup.sh
+++ b/hack/e2e/setup.sh
@@ -589,13 +589,16 @@ phase_run() {
 
     # -- Tempo --
     if has_stack tempo; then
+        _toolsets_parts+=(traces)
         case ${PROFILE} in
             openshift)
-                _toolsets_parts+=(traces)
                 _flags+=(--traces.use-route)
                 ;;
             *)
-                fail "Tempo requires OpenShift routes for local run (no --tempo-url flag). Disable the tempo stack or run with --profile openshift."
+                step "Port-forwarding Tempo query-frontend (tracing/tempo1)"
+                _run $KUBECTL port-forward -n tracing svc/tempo-tempo1-query-frontend 3200:3200 &
+                _pf_pids+=($!)
+                _flags+=(--traces.tempo-url http://localhost:3200)
                 ;;
         esac
     fi

--- a/hack/e2e/setup.sh
+++ b/hack/e2e/setup.sh
@@ -569,18 +569,18 @@ phase_run() {
         case ${PROFILE} in
             openshift)
                 step "Port-forwarding Prometheus (openshift-monitoring)"
-                $KUBECTL port-forward -n openshift-monitoring pod/prometheus-k8s-0 9090:9090 &
+                _run $KUBECTL port-forward -n openshift-monitoring pod/prometheus-k8s-0 9090:9090 &
                 _pf_pids+=($!)
                 step "Port-forwarding Alertmanager (openshift-monitoring)"
-                $KUBECTL port-forward -n openshift-monitoring pod/alertmanager-main-0 9093:9093 &
+                _run $KUBECTL port-forward -n openshift-monitoring pod/alertmanager-main-0 9093:9093 &
                 _pf_pids+=($!)
                 ;;
             *)
                 step "Port-forwarding Prometheus (monitoring)"
-                $KUBECTL port-forward -n monitoring svc/prometheus-k8s 9090:9090 &
+                _run $KUBECTL port-forward -n monitoring svc/prometheus-k8s 9090:9090 &
                 _pf_pids+=($!)
                 step "Port-forwarding Alertmanager (monitoring)"
-                $KUBECTL port-forward -n monitoring svc/alertmanager-main 9093:9093 &
+                _run $KUBECTL port-forward -n monitoring svc/alertmanager-main 9093:9093 &
                 _pf_pids+=($!)
                 ;;
         esac
@@ -624,6 +624,12 @@ phase_run() {
     # Give port-forwards a moment to bind.
     if [[ ${#_pf_pids[@]} -gt 0 ]]; then
         sleep 2
+        # check the pids are still alive and fail if some failed
+        for _pid in "${_pf_pids[@]}"; do
+            if ! kill -0 "$_pid" 2>/dev/null; then
+                fail "Port-forward process $_pid failed to start or exited unexpectedly"
+            fi
+        done
     fi
 
     step "Starting obs-mcp"
@@ -672,7 +678,3 @@ for phase in "${PHASES[@]}"; do
         *)           fail "Unknown phase: ${phase}" ;;
     esac
 done
-
-step "Cluster setup complete!"
-info "Run 'make test-e2e-deploy' to build and deploy obs-mcp"
-info "Run 'make test-e2e' to run E2E tests"

--- a/pkg/traces/common.go
+++ b/pkg/traces/common.go
@@ -38,43 +38,59 @@ var (
 	}
 )
 
-// getTempoClient returns a Tempo client based on the tempoNamespace, tempoName and tenant parameters.
+// getTempoClient returns a Tempo client based on the config and tempoNamespace, tempoName and tenant parameters.
+// When a static TempoURL is configured, it is used directly without discovery.
+// Otherwise, the Tempo instance is resolved via Kubernetes discovery using the provided parameters.
 func (t *Toolset) getTempoClient(params ToolParams) (tempoclient.Loader, error) {
+	url, err := params.resolveTempoURL()
+	if err != nil {
+		return nil, err
+	}
+	return params.newTempoLoader(url)
+}
+
+func (params ToolParams) resolveTempoURL() (string, error) {
+	if params.config != nil && params.config.TempoURL != "" {
+		return params.config.TempoURL, nil
+	}
+
 	args := params.arguments
 
 	namespace := tools.GetString(args, "tempoNamespace", "")
-	if namespace == "" {
-		return nil, errors.New("tempoNamespace parameter must not be empty")
-	}
-
 	name := tools.GetString(args, "tempoName", "")
+
+	if namespace == "" && name == "" {
+		return "", fmt.Errorf("tempo URL not configured; set tempo_url/--traces.tempo-url/TEMPO_URL or provide tempoNamespace and tempoName")
+	}
+	if namespace == "" {
+		return "", errors.New("tempoNamespace parameter must not be empty")
+	}
 	if name == "" {
-		return nil, errors.New("tempoName parameter must not be empty")
+		return "", errors.New("tempoName parameter must not be empty")
 	}
 
 	instances, err := discovery.ListInstances(params.context, params.dynamicClient, params.config.UseRoute)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	// Make sure this Tempo instance exists in cluster. Otherwise, an attacker could potentially trick the MCP tool to connect to non-Tempo services.
 	instance, err := findInstanceByName(instances, namespace, name)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	tenant := tools.GetString(args, "tenant", "")
 	if instance.Multitenancy {
 		if tenant == "" {
-			return nil, errors.New("tenant parameter must not be empty for multi-tenant instance")
+			return "", errors.New("tenant parameter must not be empty for multi-tenant instance")
 		}
 		if !slices.Contains(instance.Tenants, tenant) {
-			return nil, fmt.Errorf("tenant '%s' does not exist for instance '%s' in namespace '%s'", tenant, name, namespace)
+			return "", fmt.Errorf("tenant '%s' does not exist for instance '%s' in namespace '%s'", tenant, name, namespace)
 		}
 	}
 
-	url := instance.GetURL(tenant)
-	return params.newTempoLoader(url)
+	return instance.GetURL(tenant), nil
 }
 
 func findInstanceByName(instances []discovery.TempoInstance, namespace, name string) (discovery.TempoInstance, error) {

--- a/pkg/traces/config.go
+++ b/pkg/traces/config.go
@@ -23,6 +23,10 @@ type Config struct {
 	// Insecure controls whether to skip TLS certificate verification.
 	Insecure bool `toml:"insecure,omitempty"`
 
+	// TempoURL is the URL of the Tempo API endpoint.
+	// When set, it is used directly instead of discovering Tempo instances via Kubernetes.
+	TempoURL string `toml:"tempo_url,omitempty"`
+
 	// UseRoute controls whether to use OpenShift Routes for discovering Tempo endpoints.
 	UseRoute bool `toml:"useRoute,omitempty"`
 }

--- a/pkg/traces/handlers_test.go
+++ b/pkg/traces/handlers_test.go
@@ -255,6 +255,48 @@ func TestSearchTagValuesHandler_InvalidEndTime(t *testing.T) {
 	require.ErrorContains(t, err, "invalid end time")
 }
 
+// --- Static TempoURL ---
+
+func TestHandler_StaticTempoURL(t *testing.T) {
+	var capturedURL string
+	mock := &mockLoader{searchResult: `{"traces":[{"traceID":"abc"}],"metrics":{}}`}
+	params := ToolParams{
+		context: t.Context(),
+		config:  &Config{TempoURL: "http://my-tempo:3200"},
+		newTempoLoader: func(url string) (tempoclient.Loader, error) {
+			capturedURL = url
+			return mock, nil
+		},
+		arguments: map[string]any{
+			"query": "{}",
+		},
+	}
+
+	toolset := &Toolset{}
+	output, err := toolset.SearchTracesHandler(params)
+	require.NoError(t, err)
+	require.Len(t, output.Traces, 1)
+	require.Equal(t, "http://my-tempo:3200", capturedURL)
+}
+
+func TestHandler_NoURLAndNoDiscoveryParams(t *testing.T) {
+	// When neither TempoURL nor tempoNamespace/tempoName are provided, an error is returned.
+	params := ToolParams{
+		context: t.Context(),
+		config:  &Config{},
+		newTempoLoader: func(_ string) (tempoclient.Loader, error) {
+			return &mockLoader{}, nil
+		},
+		arguments: map[string]any{
+			"query": "{}",
+		},
+	}
+
+	toolset := &Toolset{}
+	_, err := toolset.SearchTracesHandler(params)
+	require.ErrorContains(t, err, "tempo URL not configured")
+}
+
 // --- Instance resolution errors ---
 
 func TestHandler_UnknownInstance(t *testing.T) {


### PR DESCRIPTION
Builds on https://github.com/rhobs/obs-mcp/pull/107, (starts with `dev: setup.sh run` commit, probably because I have not opened the first PR, I can't make a stacked PR)

This PR introduces:

```
make test-e2e-run
```
or equivalent:

```
./hack/e2e/setup.sh run 
```

It automates the port-forwarding setup to run the process locally, so that one doesn't have to always push everything to remote cluster. This feels better than ad-hoc targets we have for some stacks.

@slashpai I'm currently keeping it as separate, but wonder if we should just replace the `make run` with this one, and just make it a prerequisity to have a least a kind cluster around with proper e2e setup.