### PR TITLE
fix: apply bearer auth for non-TLS endpoints and improve logs error handline

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -74,10 +74,7 @@ func createRoundTripperWithToken(restConfig *rest.Config, token string, useTLS, 
 
 	if !useTLS {
 		slog.Warn("Connecting without TLS")
-		return rt, nil
-	}
-
-	if insecure {
+	} else if insecure {
 		rt.TLSClientConfig = &tls.Config{
 			MinVersion:         tls.VersionTLS12,
 			InsecureSkipVerify: true,

--- a/pkg/logs/discovery/discovery.go
+++ b/pkg/logs/discovery/discovery.go
@@ -3,6 +3,7 @@ package discovery
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -33,7 +34,8 @@ func ListInstances(ctx context.Context, k8sClient dynamic.Interface, useRoute bo
 	for _, item := range list.Items {
 		var stack LokiStack
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(item.Object, &stack); err != nil {
-			return nil, fmt.Errorf("failed to parse LokiStack: %w", err)
+			slog.Warn("Skipping unparseable LokiStack", "error", err)
+			continue
 		}
 
 		tenantsMode := ""
@@ -42,7 +44,8 @@ func ListInstances(ctx context.Context, k8sClient dynamic.Interface, useRoute bo
 		}
 		baseURL, err := resolveBaseURL(ctx, k8sClient, useRoute, stack.Namespace, stack.Name, tenantsMode)
 		if err != nil {
-			return nil, err
+			slog.Warn("Skipping LokiStack with unresolvable URL", "namespace", stack.Namespace, "name", stack.Name, "error", err)
+			continue
 		}
 		instances = append(instances, LokiInstance{
 			Namespace: stack.Namespace,

--- a/pkg/logs/handlers.go
+++ b/pkg/logs/handlers.go
@@ -239,7 +239,7 @@ func (params ToolParams) resolveLokiURL() (string, error) {
 		return instance.GetURL(), nil
 	}
 
-	return "", fmt.Errorf("loki URL not configured; set loki_url/--loki-url/LOKI_URL or provide lokiNamespace and lokiName")
+	return "", nil
 }
 
 func (params ToolParams) useRoute() bool {

--- a/pkg/logs/loki/loader.go
+++ b/pkg/logs/loki/loader.go
@@ -216,7 +216,11 @@ func (l *RealLoader) getJSON(ctx context.Context, endpoint string, params url.Va
 	if err != nil {
 		return fmt.Errorf("loki request failed: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			slog.Warn("failed to close Loki response body", "error", closeErr)
+		}
+	}()
 
 	slog.Debug("Backend call completed",
 		"backend", "loki",


### PR DESCRIPTION
Address code rabbit review comments from https://github.com/openshift/openshift-mcp-server/pull/341