### PR TITLE
GIE-515: fix: flatten AdditionalFields directly into tool Meta

### DIFF
--- a/pkg/tools/tooldef.go
+++ b/pkg/tools/tooldef.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"encoding/json"
+	"maps"
 	"reflect"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
@@ -164,9 +165,8 @@ func (d ToolDef[T]) ToServerTool(handler func(api.ToolHandlerParams) (*api.ToolC
 	}
 
 	if d.AdditionalFields != nil {
-		tool.Meta = map[string]any{
-			"AdditionalFields": d.AdditionalFields,
-		}
+		tool.Meta = make(map[string]any)
+		maps.Copy(tool.Meta, d.AdditionalFields)
 	}
 
 	return api.ServerTool{

--- a/pkg/tools/tooldef_test.go
+++ b/pkg/tools/tooldef_test.go
@@ -1,0 +1,94 @@
+package tools
+
+import (
+	"testing"
+)
+
+type testOutput struct {
+	Result string `json:"result"`
+}
+
+func TestToServerTool_AdditionalFieldsFlatInMeta(t *testing.T) {
+	def := ToolDef[testOutput]{
+		Name:        "test_tool",
+		Description: "A test tool",
+		AdditionalFields: map[string]any{
+			"olsUi": map[string]any{
+				"id": "mcp-obs/show-timeseries",
+			},
+		},
+	}
+
+	serverTool := def.ToServerTool(nil)
+
+	if serverTool.Tool.Meta == nil {
+		t.Fatal("expected Meta to be set, got nil")
+	}
+
+	olsUi, ok := serverTool.Tool.Meta["olsUi"]
+	if !ok {
+		t.Fatal("expected 'olsUi' key directly in Meta, not nested under 'AdditionalFields'")
+	}
+
+	olsUiMap, ok := olsUi.(map[string]any)
+	if !ok {
+		t.Fatalf("expected olsUi to be map[string]any, got %T", olsUi)
+	}
+
+	if id := olsUiMap["id"]; id != "mcp-obs/show-timeseries" {
+		t.Errorf("expected id 'mcp-obs/show-timeseries', got %v", id)
+	}
+
+	if _, ok := serverTool.Tool.Meta["AdditionalFields"]; ok {
+		t.Error("Meta should not contain an 'AdditionalFields' wrapper key")
+	}
+}
+
+func TestToServerTool_NilAdditionalFields(t *testing.T) {
+	def := ToolDef[testOutput]{
+		Name:        "test_tool",
+		Description: "A test tool",
+	}
+
+	serverTool := def.ToServerTool(nil)
+
+	if serverTool.Tool.Meta != nil {
+		t.Errorf("expected Meta to be nil when AdditionalFields is nil, got %v", serverTool.Tool.Meta)
+	}
+}
+
+func TestToMCPTool_AdditionalFieldsFlatInMeta(t *testing.T) {
+	def := ToolDef[testOutput]{
+		Name:        "test_tool",
+		Description: "A test tool",
+		AdditionalFields: map[string]any{
+			"olsUi": map[string]any{
+				"id": "mcp-obs/show-timeseries",
+			},
+		},
+	}
+
+	tool := def.ToMCPTool()
+
+	if tool.Meta == nil {
+		t.Fatal("expected Meta to be set, got nil")
+	}
+
+	olsUi, ok := tool.Meta["olsUi"]
+	if !ok {
+		t.Fatal("expected 'olsUi' key directly in Meta")
+	}
+
+	olsUiMap, ok := olsUi.(map[string]any)
+	if !ok {
+		t.Fatalf("expected olsUi to be map[string]any, got %T", olsUi)
+	}
+
+	if id := olsUiMap["id"]; id != "mcp-obs/show-timeseries" {
+		t.Errorf("expected id 'mcp-obs/show-timeseries', got %v", id)
+	}
+
+	if _, ok := tool.Meta["AdditionalFields"]; ok {
+		t.Error("Meta should not contain an 'AdditionalFields' wrapper key")
+	}
+}


### PR DESCRIPTION
ToServerTool() was wrapping AdditionalFields under a nested "AdditionalFields" key in Meta, while ToMCPTool() correctly copied fields flat. This caused consumers to need
toolMeta.AdditionalFields.olsUi instead of toolMeta.olsUi.


Assisted-by: Claude Code:claude-opus-4-6
(cherry picked from commit 9216aad648d171041454c72f518f14cd278e0496)