### PR TITLE
ci: skip lint, unit, and e2e workflows for doc-only changes

### DIFF
--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -1,0 +1,28 @@
+name: changed-files
+
+on:
+    workflow_call:
+        outputs:
+            non-markdown-files:
+                description: "Non-empty if non-markdown files changed"
+                value: ${{ jobs.changed-files.outputs.non-markdown-files }}
+
+jobs:
+    changed-files:
+        outputs:
+            non-markdown-files: ${{ steps.changed-files.outputs.non-markdown-files }}
+        runs-on: ubuntu-latest
+        steps:
+            - name: checkout
+              uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
+            - name: get changed files
+              id: changed-files
+              run: |
+                  if [ "${{ github.event_name }}" = "pull_request" ]; then
+                    echo "non-markdown-files=$(git diff --name-only --diff-filter=ACMRT ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep -iv '\.md$' | xargs)" >> "$GITHUB_OUTPUT"
+                  else
+                    # Always run on push and merge_group events
+                    echo "non-markdown-files=true" >> "$GITHUB_OUTPUT"
+                  fi

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -12,8 +12,13 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+    changed-files:
+        uses: ./.github/workflows/changed-files.yaml
+
     e2e-tests:
         name: E2E tests
+        needs: changed-files
+        if: ${{ needs.changed-files.outputs.non-markdown-files }}
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,8 +11,13 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+    changed-files:
+        uses: ./.github/workflows/changed-files.yaml
+
     golangci-lint:
         name: golangci-lint
+        needs: changed-files
+        if: ${{ needs.changed-files.outputs.non-markdown-files }}
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -12,8 +12,13 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+    changed-files:
+        uses: ./.github/workflows/changed-files.yaml
+
     unit:
         name: unit tests
+        needs: changed-files
+        if: ${{ needs.changed-files.outputs.non-markdown-files }}
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code


### PR DESCRIPTION
Add a reusable changed-files workflow that detects whether non-markdown files were modified in a PR. The lint, unit, and e2e workflows now call it and skip their jobs when only documentation is updated.

This is based on method we use in operator which will save ci cycles for doc only updates https://github.com/prometheus-operator/prometheus-operator/blob/main/.github/workflows/changed-files.yaml https://github.com/perses/perses-operator/blob/main/.github/workflows/changed-files.yaml