### PR TITLE
fix: bump go version to 1.25.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rhobs/obs-mcp
 
-go 1.25.7
+go 1.25.9
 
 require (
 	github.com/BurntSushi/toml v1.6.0

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/rhobs/obs-mcp/hack/tools
 
-go 1.24.6
+go 1.25.9
 
 tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 


### PR DESCRIPTION
As Its been updated in https://github.com/openshift/openshift-mcp-server/pull/343 as well
