### PR TITLE
e2e: enable span metrics for traces

### DIFF
--- a/manifests/tempo/extras/base/04_otel.yaml
+++ b/manifests/tempo/extras/base/04_otel.yaml
@@ -4,6 +4,9 @@ metadata:
   name: otel
   namespace: tracing
 spec:
+  observability:
+    metrics:
+      enableMetrics: true
   config:
     receivers:
       otlp:
@@ -17,16 +20,34 @@ spec:
           thrift_compact:
             endpoint: 0.0.0.0:6831
 
+    connectors:
+      spanmetrics:
+        dimensions:
+        - name: k8s.namespace.name
+        - name: k8s.deployment.name
+        - name: k8s.statefulset.name
+        - name: k8s.daemonset.name
+        - name: k8s.container.name
+        - name: k8s.cronjob.name
+        - name: k8s.node.name
+        - name: k8s.cluster.name
+
     processors:
       k8sattributes: {}
 
     exporters:
       otlp_http/tempo1:
         endpoint: http://tempo-tempo1-distributor.tracing:4318
+      prometheus:
+        endpoint: 0.0.0.0:8889
 
     service:
       pipelines:
         traces:
           receivers: [otlp, jaeger]
           processors: [k8sattributes]
-          exporters: [otlp_http/tempo1]
+          exporters: [otlp_http/tempo1, spanmetrics]
+        metrics:
+          receivers: [spanmetrics]
+          processors: []
+          exporters: [prometheus]

--- a/manifests/tempo/extras/kubernetes/kustomization.yaml
+++ b/manifests/tempo/extras/kubernetes/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - rbac.yaml
 patches:
   - path: patches/otel-image.yaml
     target:

--- a/manifests/tempo/extras/kubernetes/rbac.yaml
+++ b/manifests/tempo/extras/kubernetes/rbac.yaml
@@ -1,0 +1,24 @@
+# allow prometheus to discover otel-collector scrape targets in the tracing namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: tracing
+rules:
+- apiGroups: [""]
+  resources: ["services", "endpoints", "pods"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: tracing
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: monitoring

--- a/manifests/tempo/extras/openshift/kustomization.yaml
+++ b/manifests/tempo/extras/openshift/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - user-workload-monitoring.yaml
   - tempo-multitenant.yaml
   - rbac.yaml
 patches:

--- a/manifests/tempo/extras/openshift/patches/otel-tempo-tenant.yaml
+++ b/manifests/tempo/extras/openshift/patches/otel-tempo-tenant.yaml
@@ -23,4 +23,4 @@ spec:
       extensions: [bearertokenauth]
       pipelines:
         traces:
-          exporters: [otlp_http/tempo1, otlp/project1]
+          exporters: [otlp_http/tempo1, otlp/project1, spanmetrics]

--- a/manifests/tempo/extras/openshift/user-workload-monitoring.yaml
+++ b/manifests/tempo/extras/openshift/user-workload-monitoring.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true


### PR DESCRIPTION
Enable the spanmetrics connector in OTEL, to generate RED (rate, error, duration) metrics from traces.

In the future I want to instruct the agent to combine metrics and traces for troubleshooting scenarios (e.g. find the affected service with metrics, and find a resolution by looking at a trace).
