### PR TITLE
tempo_search_traces: establish latency baseline instead of guessing

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -507,6 +507,13 @@ _No parameters._
 > Search for distributed traces in Tempo using TraceQL.
 > Use this tool to find traces matching specific criteria such as service name, HTTP status code, duration, or other span or resource attributes.
 
+<details>
+<summary><strong>Usage Tips</strong></summary>
+
+- IMPORTANT — "slow" or "long" trace requests: Do NOT guess a duration threshold. First call this tool WITHOUT a duration filter to establish a latency baseline, then use that baseline to set a sensible threshold. Both steps are required — do NOT skip the second search with the duration filter. Skip this two-step process only when the user provides an explicit duration (e.g. "find traces slower than 2s").
+
+</details>
+
 **Parameters:**
 
 **Required:**

--- a/evals/mcpchecker/eval.yaml
+++ b/evals/mcpchecker/eval.yaml
@@ -431,6 +431,21 @@ config:
         minToolCalls: 2
         maxToolCalls: 5
 
+    - path: tasks/traces/latency-baseline.yaml
+      assertions:
+        toolsUsed:
+          - server: obs
+            tool: tempo_search_traces
+        callOrder:
+          - type: tool
+            server: obs
+            name: tempo_search_traces
+          - type: tool
+            server: obs
+            name: tempo_search_traces
+        minToolCalls: 3
+        maxToolCalls: 5
+
     # OpenTelemetry Collector
     - path: tasks/otelcol/get-versions.yaml
       assertions:

--- a/evals/mcpchecker/tasks/traces/latency-baseline.yaml
+++ b/evals/mcpchecker/tasks/traces/latency-baseline.yaml
@@ -1,0 +1,27 @@
+kind: Task
+apiVersion: mcpchecker/v1alpha2
+metadata:
+  name: latency-baseline
+  difficulty: medium
+  parallel: true
+  runs: 1
+  labels:
+    category: traces
+    suite: observability
+    toolType: query
+  description: |
+    Tests if the agent establishes a latency baseline by first searching
+    for recent traces (without a duration filter) to observe the typical
+    latency range, before searching for high latency traces with a
+    duration filter.
+spec:
+  prompt:
+    inline: |
+      Find slow traces of the shop-backend service. Use instance tempo1.
+  verify:
+    - llmJudge:
+        contains: "duration"
+        reason: "Verify the agent first searched for recent traces WITHOUT a duration filter to establish a latency baseline, and THEN searched again WITH a duration filter derived from the baseline results. The agent must NOT have guessed an arbitrary threshold like 1s or 500ms."
+    - llmJudge:
+        contains: "article-to-cart"
+        reason: "Verify the agent found slow traces of the shop-backend service"

--- a/evals/mcpchecker/tasks/traces/latency-investigation.yaml
+++ b/evals/mcpchecker/tasks/traces/latency-investigation.yaml
@@ -2,7 +2,7 @@ kind: Task
 apiVersion: mcpchecker/v1alpha2
 metadata:
   name: latency-investigation
-  difficulty: medium
+  difficulty: easy
   parallel: true
   runs: 1
   labels:

--- a/evals/mcpchecker/tasks/traces/search-error-traces.yaml
+++ b/evals/mcpchecker/tasks/traces/search-error-traces.yaml
@@ -2,7 +2,7 @@ kind: Task
 apiVersion: mcpchecker/v1alpha2
 metadata:
   name: search-error-traces
-  difficulty: medium
+  difficulty: easy
   parallel: true
   runs: 1
   labels:

--- a/pkg/traces/search_traces.go
+++ b/pkg/traces/search_traces.go
@@ -17,7 +17,13 @@ type SearchTracesOutput struct {
 var SearchTracesTool = tools.ToolDef[SearchTracesOutput]{
 	Name: "tempo_search_traces",
 	Description: `Search for distributed traces in Tempo using TraceQL.
-Use this tool to find traces matching specific criteria such as service name, HTTP status code, duration, or other span or resource attributes.`,
+Use this tool to find traces matching specific criteria such as service name, HTTP status code, duration, or other span or resource attributes.
+
+IMPORTANT — "slow" or "long" trace requests: Do NOT guess a duration threshold.
+First call this tool WITHOUT a duration filter to establish a latency baseline, then use that baseline to set a sensible threshold.
+Both steps are required — do NOT skip the second search with the duration filter.
+Skip this two-step process only when the user provides an explicit duration (e.g. "find traces slower than 2s").
+`,
 	Title: "Search traces",
 	Params: []tools.ParamDef{
 		tempoNamespaceParameter,


### PR DESCRIPTION
Establish latency baseline for "slow" traces instead of guessing a random "slow" duration.