### PR TITLE
evals: change default model from gpt-5-nano to gpt-4o-mini

### DIFF
--- a/evals/mcpchecker/eval.yaml
+++ b/evals/mcpchecker/eval.yaml
@@ -5,14 +5,20 @@ metadata:
 config:
   agent:
     type: "builtin.llm-agent"
-    model: "openai:gpt-5-nano"
+    model: "openai:gpt-4o-mini"
+
+    # Alternative using Claude Code
+    # type: "builtin.claude-code"
 
   mcpConfigFile: mcp-config.yaml
 
   llmJudge:
     ref:
       type: builtin.llm-agent
-      model: "openai:gpt-5-nano"
+      model: "openai:gpt-4o-mini"
+
+      # Alternative using Claude Code
+      # type: "builtin.claude-code"
 
   taskSets:
     # Smoke test


### PR DESCRIPTION
`gpt-5-nano` ignores tool descriptions frequently, while `gpt-4o-mini` is more careful (but a bit more expensive).

E.g. for #143 `gpt-5-nano` frequently failed, where `gpt-4o-mini` mostly passed the eval.