### PR TITLE
chore: add deploy-and-eval claude code skill

### DIFF
--- a/.agents/skills/deploy-and-eval/SKILL.md
+++ b/.agents/skills/deploy-and-eval/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: deploy-and-eval
+description: Build, deploy, and run evals on the obs-mcp test cluster
+user-invocable: true
+---
+
+# Deploy and Evaluate obs-mcp
+
+Follow these steps to build, deploy, and run evals.
+
+## Step 1: Build and deploy
+
+Build and deploy changes to the test cluster:
+```
+TAG=$(date +%s) make test-e2e-deploy
+```
+
+## Step 2: Set up port forwarding
+
+Set up port forwarding to the deployed service (long-running task, run in background):
+```
+make test-e2e-pf
+```
+
+## Step 3: Run evaluations
+
+Run evals. Ask the user which task, category, or all evals to run, then execute:
+```
+# Run a specific task:
+make run-mcpchecker-eval TASK=<task> RUNS=<number of iterations, default: 1>
+# Run all tasks in a category:
+make run-mcpchecker-eval CATEGORY=<category> RUNS=<number of iterations, default: 1>
+# Run all evals:
+make run-mcpchecker-eval RUNS=<number of iterations, default: 1>
+```

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ tmp/*
 manifests/core/deploy/overlay
 manifests/loki/extras/overlay
 /vendor
-/.claude
+/.claude/settings.local.json
 
 cpu.prof
 mem.prof


### PR DESCRIPTION
To simplify an agentic loop of e.g. **update tool description -> redeploy -> run evals -> repeat (on failures)**, I added a `deploy-and-eval` Claude Code skill.