### PR TITLE
RHOBS-1622(change): namespace obs-mcp toolset names with observability prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Namespace all toolset names with `observability/` prefix for clarity in user configuration: `metrics` → `observability/metrics`, `traces` → `observability/traces`, `logs` → `observability/logs`, `otelcol` → `observability/otelcol`
+
 ## [v0.4.0] - 2026-06-17
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -109,13 +109,13 @@ check-tools-doc: generate-tools-doc ## Check if TOOLS.md is up to date
 LISTEN_ADDR ?= :9100
 LOG_LEVEL ?= debug
 AUTH_MODE ?= kubeconfig
-TOOLSETS ?= metrics
+TOOLSETS ?= observability/metrics
 RUN_FLAGS ?= --loki.use-route
 
 .PHONY: run
 run: build ## Run obs-mcp in HTTP mode (use LOG_LEVEL=debug to see backend call timings)
 	@echo "Tip: Override backend URLs with PROMETHEUS_URL=https://... ALERTMANAGER_URL=https://... make run"
-	@echo "Tip: Override toolsets with TOOLSETS=metrics,traces,otelcol make run"
+	@echo "Tip: Override toolsets with TOOLSETS=observability/metrics,observability/traces,observability/otelcol make run"
 	@echo "Note: AUTH_MODE=serviceaccount or header requires PROMETHEUS_URL and ALERTMANAGER_URL to be set"
 	./obs-mcp --listen $(LISTEN_ADDR) --auth-mode $(AUTH_MODE) --insecure --log-level $(LOG_LEVEL) --toolsets $(TOOLSETS) $(RUN_FLAGS)
 
@@ -154,7 +154,7 @@ run-pf-loki: build ## Port-forward loki and start obs-mcp with header auth
 		sleep 2; \
 		trap "kill $$PF_LOKI_PID 2>/dev/null" EXIT; \
 		LOKI_URL=http://localhost:8080 \
-		./obs-mcp --listen $(LISTEN_ADDR) --auth-mode header --log-level $(LOG_LEVEL) --toolsets logs
+		./obs-mcp --listen $(LISTEN_ADDR) --auth-mode header --log-level $(LOG_LEVEL) --toolsets observability/logs
 
 .PHONY: inspect
 inspect: COMPOSE_HOST_GATEWAY = $(if $(filter podman,$(CONTAINER_CLI)),host.containers.internal,host.docker.internal)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![e2e](https://github.com/rhobs/obs-mcp/actions/workflows/e2e.yaml/badge.svg)](https://github.com/rhobs/obs-mcp/actions/workflows/e2e.yaml)
 [![docs](https://github.com/rhobs/obs-mcp/actions/workflows/docs.yaml/badge.svg)](https://github.com/rhobs/obs-mcp/actions/workflows/docs.yaml)
 
-obs-mcp is an [MCP](https://modelcontextprotocol.io/introduction) server that lets LLMs query [Prometheus](https://prometheus.io/) or [Thanos Querier](https://thanos.io/) and [Alertmanager](https://prometheus.io/docs/alerting/latest/alertmanager/) in Kubernetes. It optionally supports [Loki](https://grafana.com/oss/loki/) for logs, [Grafana Tempo](https://grafana.com/docs/tempo/latest/) for traces, and [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) configuration assistance. Enable additional toolsets with `--toolsets` (e.g., `--toolsets metrics,logs,traces,otelcol`).
+obs-mcp is an [MCP](https://modelcontextprotocol.io/introduction) server that lets LLMs query [Prometheus](https://prometheus.io/) or [Thanos Querier](https://thanos.io/) and [Alertmanager](https://prometheus.io/docs/alerting/latest/alertmanager/) in Kubernetes. It optionally supports [Loki](https://grafana.com/oss/loki/) for logs, [Grafana Tempo](https://grafana.com/docs/tempo/latest/) for traces, and [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) configuration assistance. Enable additional toolsets with `--toolsets` (e.g., `--toolsets observability/metrics,observability/logs,observability/traces,observability/otelcol`).
 
 > [!NOTE]
 > This project is moved from [jhadvig/genie-plugin](https://github.com/jhadvig/genie-plugin/tree/main/obs-mcp) preserving the history of commits.
@@ -79,7 +79,7 @@ go run ./cmd/obs-mcp/ --listen 127.0.0.1:9100 --auth-mode kubeconfig --metrics-b
   ```
 
 > [!IMPORTANT]
-> **How the Loki URL is Determined (when `logs` toolset is enabled):**
+> **How the Loki URL is Determined (when `observability/logs` toolset is enabled):**
 >
 > 1. `--loki-url` flag (if set)
 > 2. `LOKI_URL` environment variable
@@ -162,13 +162,13 @@ You can test the MCP server using curl. The server uses `JSON-RPC 2.0` over `HTT
 **List available tools:**
 
 > [!NOTE]
-> The default `--toolsets` value is `metrics` only. Additional toolsets:
+> The default `--toolsets` value is `observability/metrics` only. Additional toolsets:
 >
-> - `logs` - Loki log query tools (requires Loki URL or LokiStack discovery)
-> - `traces` - Tempo tracing tools (requires Tempo configuration)
-> - `otelcol` - OpenTelemetry Collector configuration assistance (no external dependencies)
+> - `observability/logs` - Loki log query tools (requires Loki URL or LokiStack discovery)
+> - `observability/traces` - Tempo tracing tools (requires Tempo configuration)
+> - `observability/otelcol` - OpenTelemetry Collector configuration assistance (no external dependencies)
 >
-> Example: `--toolsets metrics,logs,traces,otelcol`
+> Example: `--toolsets observability/metrics,observability/logs,observability/traces,observability/otelcol`
 
 ```shell
 curl -X POST http://localhost:9100/mcp \

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -58,7 +58,7 @@ The `--auth-mode` flag controls how obs-mcp obtains bearer tokens for **Promethe
 
 - Reads the service account token mounted inside the pod
 - Requires explicit `PROMETHEUS_URL` (no auto-discovery)
-- If `logs` toolset is enabled, either set `LOKI_URL`/`--loki-url` or use LokiStack discovery parameters (`lokiNamespace`, `lokiName`)
+- If `observability/logs` toolset is enabled, either set `LOKI_URL`/`--loki-url` or use LokiStack discovery parameters (`lokiNamespace`, `lokiName`)
 - The ServiceAccount must have RBAC permissions to query the metrics endpoint
 - Best for: **In-cluster deployment** on OpenShift with RBAC-protected Thanos/Prometheus
 
@@ -67,7 +67,7 @@ The `--auth-mode` flag controls how obs-mcp obtains bearer tokens for **Promethe
 - Forwards the `Authorization` header from incoming MCP client requests to Prometheus
 - If no header is provided, connects without authentication
 - Requires explicit `PROMETHEUS_URL` (no auto-discovery)
-- If `logs` toolset is enabled, either set `LOKI_URL`/`--loki-url` or use LokiStack discovery parameters (`lokiNamespace`, `lokiName`)
+- If `observability/logs` toolset is enabled, either set `LOKI_URL`/`--loki-url` or use LokiStack discovery parameters (`lokiNamespace`, `lokiName`)
 - Best for: **Pass-through auth** scenarios or **Prometheus without authentication** (e.g., port-forwarded, local kube-prometheus)
 
 ## Deploying on a Cluster
@@ -105,14 +105,14 @@ comma-separated list via `--stacks` (default: `prometheus,tempo,loki`):
 
 | Stack        | What it installs                                                       | Toolset enabled |
 | ------------ | ---------------------------------------------------------------------- | --------------- |
-| `prometheus` | kube-prometheus (k8s) or uses the built-in OpenShift monitoring stack  | `metrics`       |
-| `tempo`      | Tempo + OpenTelemetry operators and a sample tracing app               | `traces`        |
-| `loki`       | Loki Operator test stack                                               | `logs`          |
+| `prometheus` | kube-prometheus (k8s) or uses the built-in OpenShift monitoring stack  | `observability/metrics` |
+| `tempo`      | Tempo + OpenTelemetry operators and a sample tracing app               | `observability/traces`  |
+| `loki`       | Loki Operator test stack                                               | `observability/logs`    |
 
 The enabled stacks determine which `manifests/` subtrees are applied and which `--toolsets`
 value is passed to the obs-mcp deployment — no manual editing of manifests is needed.
-When deploying via `hack/e2e/setup.sh`, the `otelcol` toolset is always included (it has no
-external backend dependency); stack selection adds `metrics`, `traces`, and/or `logs` on top.
+When deploying via `hack/e2e/setup.sh`, the `observability/otelcol` toolset is always included (it has no
+external backend dependency); stack selection adds `observability/metrics`, `observability/traces`, and/or `observability/logs` on top.
 
 **Phases** express what work to perform. The two top-level aliases cover the common cases:
 
@@ -147,7 +147,7 @@ manifests/
 When deploying in-cluster, you must configure:
 
 1. **`PROMETHEUS_URL`**: Set the environment variable to your Prometheus/Thanos endpoint
-2. **`LOKI_URL`**: Optional when using the `logs` toolset (or pass `--loki-url`). If omitted, use LokiStack discovery (`loki_list_instances` + `lokiNamespace`/`lokiName` tool arguments)
+2. **`LOKI_URL`**: Optional when using the `observability/logs` toolset (or pass `--loki-url`). If omitted, use LokiStack discovery (`loki_list_instances` + `lokiNamespace`/`lokiName` tool arguments)
 3. **`--auth-mode`**: Choose based on your backend authentication requirements:
    - `serviceaccount` if your Prometheus requires RBAC/token auth
    - `header` if your Prometheus doesn't require authentication

--- a/evals/mcpchecker/README.md
+++ b/evals/mcpchecker/README.md
@@ -5,7 +5,7 @@ Evaluations for obs-mcp using [mcpchecker](https://github.com/mcpchecker/mcpchec
 ## Pre-requisites
 
 - [mcpchecker](https://github.com/mcpchecker/mcpchecker#install) installed (v0.0.16+) — run `make install-mcpchecker` from the repo root
-- **Metrics / alerts / traces / otelcol:** Kubernetes or OpenShift cluster with Prometheus and Alertmanager (see [Setup the cluster](#setup-the-cluster))
+- **Metrics / alerts / traces / otelcol:** Kubernetes or OpenShift cluster with Prometheus and Alertmanager (see [Setup the cluster](#setup-the-cluster)). Toolsets are namespaced as `observability/metrics`, `observability/traces`, `observability/logs`, `observability/otelcol`.
 - **obs-mcp** running at `http://localhost:9100/mcp` before any mcpchecker run
 
 ## Environment Variables

--- a/evals/mcpchecker/eval.yaml
+++ b/evals/mcpchecker/eval.yaml
@@ -487,7 +487,7 @@ config:
         minToolCalls: 1
         maxToolCalls: 3
 
-    # Logs (Loki) — requires --toolsets logs on obs-mcp; see evals/mcpchecker/README.md
+    # Logs (Loki) — requires --toolsets observability/logs on obs-mcp; see evals/mcpchecker/README.md
     - path: tasks/logs/loki-backend-reachability.yaml
       assertions:
         toolsUsed:

--- a/evals/mcpchecker/tasks/logs/loki-backend-reachability.yaml
+++ b/evals/mcpchecker/tasks/logs/loki-backend-reachability.yaml
@@ -11,7 +11,7 @@ metadata:
     toolType: smoke-test
   description: |
     Smoke test that the agent can reach Loki via loki_list_instances and report
-    a discovered LokiStack. Run obs-mcp with --toolsets logs (or metrics,traces,logs).
+    a discovered LokiStack. Run obs-mcp with --toolsets observability/logs (or observability/metrics,observability/traces,observability/logs).
 spec:
   prompt:
     inline: |

--- a/hack/e2e/setup.sh
+++ b/hack/e2e/setup.sh
@@ -477,10 +477,10 @@ phase_deploy() {
     step "Deploying obs-mcp"
 
     # Compute toolsets from enabled stacks
-    _toolsets_parts=(otelcol)
-    has_stack prometheus && _toolsets_parts+=(metrics)
-    has_stack tempo      && _toolsets_parts+=(traces)
-    has_stack loki       && _toolsets_parts+=(logs)
+    _toolsets_parts=(observability/otelcol)
+    has_stack prometheus && _toolsets_parts+=(observability/metrics)
+    has_stack tempo      && _toolsets_parts+=(observability/traces)
+    has_stack loki       && _toolsets_parts+=(observability/logs)
     _toolsets=$(IFS=,; echo "${_toolsets_parts[*]}")
 
     # Build a temporary kustomize overlay to inject runtime values (toolsets, image)
@@ -566,11 +566,11 @@ phase_run() {
     )
 
     # Toolsets — always include otelcol.
-    local _toolsets_parts=(otelcol)
+    local _toolsets_parts=(observability/otelcol)
 
     # -- Prometheus & Alertmanager --
     if has_stack prometheus; then
-        _toolsets_parts+=(metrics)
+        _toolsets_parts+=(observability/metrics)
         case ${PROFILE} in
             openshift)
                 step "Port-forwarding Prometheus (openshift-monitoring)"
@@ -594,7 +594,7 @@ phase_run() {
 
     # -- Tempo --
     if has_stack tempo; then
-        _toolsets_parts+=(traces)
+        _toolsets_parts+=(observability/traces)
         case ${PROFILE} in
             openshift)
                 _flags+=(--traces.use-route)
@@ -610,7 +610,7 @@ phase_run() {
 
     # -- Loki --
     if has_stack loki; then
-        _toolsets_parts+=(logs)
+        _toolsets_parts+=(observability/logs)
         case ${PROFILE} in
             openshift)
                 _flags+=(--loki.use-route)

--- a/manifests/core/deploy/kubernetes/configmap.yaml
+++ b/manifests/core/deploy/kubernetes/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: obs-mcp
 data:
   auth-mode: "header"
-  toolsets: "metrics,traces,otelcol"
+  toolsets: "observability/metrics,observability/traces,observability/otelcol"
   # this is the default prometheus url for kube-prometheus stack
   prometheus-url: "http://prometheus-k8s.monitoring.svc:9090"
   # this is the default alertmanager url for kube-prometheus stack

--- a/manifests/core/deploy/openshift/configmap.yaml
+++ b/manifests/core/deploy/openshift/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: obs-mcp
 data:
   auth-mode: "serviceaccount"
-  toolsets: "metrics,traces,otelcol"
+  toolsets: "observability/metrics,observability/traces,observability/otelcol"
   # OpenShift monitoring Prometheus URL (port 9091 for OAuth proxy)
   prometheus-url: "https://prometheus-k8s.openshift-monitoring.svc:9091"
   # OpenShift monitoring Alertmanager URL (port 9094 for kube-rbac-proxy)

--- a/pkg/logs/toolset.go
+++ b/pkg/logs/toolset.go
@@ -6,7 +6,7 @@ import (
 	"github.com/rhobs/obs-mcp/pkg/logs/loki"
 )
 
-const ToolsetName = "logs"
+const ToolsetName = "observability/logs"
 
 // Toolset implements the observability toolset for Loki.
 type Toolset struct {

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -29,10 +29,10 @@ import (
 type Toolset string
 
 const (
-	ToolsetMetrics Toolset = "metrics"
-	ToolsetTraces  Toolset = "traces"
-	ToolsetLogs    Toolset = "logs"
-	ToolsetOtelcol Toolset = "otelcol"
+	ToolsetMetrics Toolset = "observability/metrics"
+	ToolsetTraces  Toolset = "observability/traces"
+	ToolsetLogs    Toolset = "observability/logs"
+	ToolsetOtelcol Toolset = "observability/otelcol"
 )
 
 var AllToolsets = []string{string(ToolsetMetrics), string(ToolsetTraces), string(ToolsetLogs), string(ToolsetOtelcol)}

--- a/pkg/otelcol/toolset.go
+++ b/pkg/otelcol/toolset.go
@@ -14,7 +14,7 @@ import (
 	"github.com/rhobs/obs-mcp/pkg/resultutil"
 )
 
-const ToolsetName = "otelcol"
+const ToolsetName = "observability/otelcol"
 
 // Config holds OpenTelemetry Collector toolset configuration.
 type Config struct {

--- a/pkg/toolset/config/config.go
+++ b/pkg/toolset/config/config.go
@@ -12,7 +12,7 @@ import (
 	"github.com/rhobs/obs-mcp/pkg/prometheus"
 )
 
-const MetricsToolSetName = "metrics"
+const MetricsToolSetName = "observability/metrics"
 
 // Config holds obs-mcp toolset configuration
 type Config struct {

--- a/pkg/traces/toolset.go
+++ b/pkg/traces/toolset.go
@@ -6,7 +6,7 @@ import (
 	tempoclient "github.com/rhobs/obs-mcp/pkg/traces/tempo"
 )
 
-const ToolsetName = "traces"
+const ToolsetName = "observability/traces"
 
 // Toolset implements the observability toolset for Tempo.
 type Toolset struct {


### PR DESCRIPTION
Addresses feedback from https://github.com/openshift/openshift-mcp-server/pull/341#issuecomment-4745446802 (@Cali0707):
> I think some of the toolset names coming in here from the rh-obs package are a bit too generic. The tool names themselves seem great, but from a user config perspective logs or traces is a bit general. Could you make these all namespaced, like observability/logs, observability/traces, etc?

**Note:** This is a breaking change for users who reference toolset names in `--toolsets` flags, TOML config sections, or ConfigMaps.
