### PR TITLE
cmd: fix stdin mode

### DIFF
--- a/cmd/obs-mcp/main.go
+++ b/cmd/obs-mcp/main.go
@@ -207,8 +207,7 @@ func main() {
 		}
 	} else {
 		// Start server on stdio (default mode)
-		transport := &mcp.StdioTransport{}
-		if _, err := mcpServer.Connect(context.Background(), transport, nil); err != nil {
+		if err := mcpServer.Run(context.Background(), &mcp.StdioTransport{}); err != nil {
 			log.Fatalf("Server failed: %v", err)
 		}
 	}


### PR DESCRIPTION
Before the fix, the stdio mode stopped immediately.

To verify, run obs-mcp without passing the `--listen` option.

After the fix, the obs-mcp was working fine in a local AI coding agent.