### PR TITLE
breaking: change useRoute to use_route in toolset config for traces and logs

### DIFF
--- a/pkg/logs/config.go
+++ b/pkg/logs/config.go
@@ -27,7 +27,7 @@ type Config struct {
 	Insecure bool `toml:"insecure,omitempty"`
 
 	// UseRoute controls whether to use OpenShift Routes for discovering LokiStack endpoints.
-	UseRoute bool `toml:"useRoute,omitempty"`
+	UseRoute bool `toml:"use_route,omitempty"`
 }
 
 var _ api.ExtendedConfig = (*Config)(nil)

--- a/pkg/traces/config.go
+++ b/pkg/traces/config.go
@@ -28,7 +28,7 @@ type Config struct {
 	TempoURL string `toml:"tempo_url,omitempty"`
 
 	// UseRoute controls whether to use OpenShift Routes for discovering Tempo endpoints.
-	UseRoute bool `toml:"useRoute,omitempty"`
+	UseRoute bool `toml:"use_route,omitempty"`
 }
 
 var _ api.ExtendedConfig = (*Config)(nil)


### PR DESCRIPTION
For consistency with other toolset configs and TOML, use use snake_case instead of camelCase for the UseRoute config.

This config is mainly for dev, so while a breaking change, it shouldn't have a big impact.