### PR TITLE
test: add e2e test with openshift-mcp-server

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -33,6 +33,18 @@ jobs:
             - name: Run E2E tests
               run: make test-e2e
 
+            - name: Verify usage with openshift-mcp-server
+              run: |
+                ./hack/e2e/setup.sh deploy-oms --profile kind
+                kubectl port-forward -n openshift-mcp-server svc/openshift-mcp-server 9100:9100 &
+                sleep 3
+                TOOLS=$(npx @modelcontextprotocol/inspector --cli http://localhost:9100/mcp --method tools/list)
+                echo "$TOOLS"
+                echo "$TOOLS" | grep -q 'list_metrics' || (echo "ERROR: no list_metrics tool found"; exit 1)
+                echo "$TOOLS" | grep -q 'tempo_' || (echo "ERROR: no tempo_ tools found"; exit 1)
+                echo "$TOOLS" | grep -q 'loki_' || (echo "ERROR: no loki_ tools found"; exit 1)
+                echo "$TOOLS" | grep -q 'otelcol_' || (echo "ERROR: no otelcol_ tools found"; exit 1)
+
             - name: Collect diagnostics on failure
               if: ${{ failure() }}
               run: |
@@ -40,6 +52,8 @@ jobs:
                   kubectl get pods -A
                   echo "=== obs-mcp logs ==="
                   kubectl logs -n obs-mcp -l app.kubernetes.io/name=obs-mcp --tail=100 || true
+                  echo "=== openshift-mcp-server logs ==="
+                  kubectl logs -n openshift-mcp-server -l app.kubernetes.io/name=openshift-mcp-server --tail=100 || true
                   echo "=== Prometheus logs ==="
                   kubectl logs -n monitoring -l app.kubernetes.io/name=prometheus --tail=50 || true
                   echo "=== Events ==="

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -33,9 +33,35 @@ jobs:
             - name: Run E2E tests
               run: make test-e2e
 
-            - name: Verify usage with openshift-mcp-server
+            - name: Collect diagnostics on failure
+              if: ${{ failure() }}
               run: |
-                ./hack/e2e/setup.sh deploy-oms --profile kind
+                  echo "=== Pod status ==="
+                  kubectl get pods -A
+                  echo "=== obs-mcp logs ==="
+                  kubectl logs -n obs-mcp -l app.kubernetes.io/name=obs-mcp --tail=100 || true
+                  echo "=== Prometheus logs ==="
+                  kubectl logs -n monitoring -l app.kubernetes.io/name=prometheus --tail=50 || true
+                  echo "=== Events ==="
+                  kubectl get events -n obs-mcp --sort-by='.lastTimestamp' || true
+
+    e2e-openshift-mcp-server:
+        name: E2E tests with openshift-mcp-server
+        needs: changed-files
+        if: ${{ needs.changed-files.outputs.non-markdown-files }}
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v6
+
+            - name: Setup E2E environment
+              uses: ./.github/actions/setup-e2e
+
+            - name: Deploy openshift-mcp-server
+              run: ./hack/e2e/setup.sh provision prereqs deploy-oms --profile kind
+
+            - name: Verify tools
+              run: |
                 kubectl port-forward -n openshift-mcp-server svc/openshift-mcp-server 9100:9100 &
                 sleep 3
                 TOOLS=$(npx @modelcontextprotocol/inspector --cli http://localhost:9100/mcp --method tools/list)
@@ -50,11 +76,7 @@ jobs:
               run: |
                   echo "=== Pod status ==="
                   kubectl get pods -A
-                  echo "=== obs-mcp logs ==="
-                  kubectl logs -n obs-mcp -l app.kubernetes.io/name=obs-mcp --tail=100 || true
                   echo "=== openshift-mcp-server logs ==="
                   kubectl logs -n openshift-mcp-server -l app.kubernetes.io/name=openshift-mcp-server --tail=100 || true
-                  echo "=== Prometheus logs ==="
-                  kubectl logs -n monitoring -l app.kubernetes.io/name=prometheus --tail=50 || true
                   echo "=== Events ==="
-                  kubectl get events -n obs-mcp --sort-by='.lastTimestamp' || true
+                  kubectl get events -n openshift-mcp-server --sort-by='.lastTimestamp' || true

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ integration-tests/screenshots
 tmp/*
 manifests/core/deploy/overlay
 manifests/loki/extras/overlay
+manifests/openshift-mcp-server/deploy/overlay
 /vendor
 /.claude/settings.local.json
 

--- a/Containerfile.openshift-mcp-server
+++ b/Containerfile.openshift-mcp-server
@@ -1,0 +1,24 @@
+FROM --platform=$BUILDPLATFORM golang:latest AS builder
+
+ARG TARGETOS=linux
+ARG TARGETARCH=amd64
+
+WORKDIR /app
+ADD https://github.com/openshift/openshift-mcp-server/archive/refs/heads/main.tar.gz .
+RUN tar xzf main.tar.gz --strip-components=1
+
+COPY . /obs-mcp
+RUN go mod edit -replace github.com/rhobs/obs-mcp=/obs-mcp && \
+    go mod tidy && \
+    go mod vendor
+
+RUN make build-multiarch TARGETOS=${TARGETOS} TARGETARCH=${TARGETARCH}
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+LABEL io.modelcontextprotocol.server.name="io.github.containers/kubernetes-mcp-server"
+WORKDIR /app
+COPY --from=builder /app/kubernetes-mcp-server /app/kubernetes-mcp-server
+USER 65532:65532
+ENTRYPOINT ["/app/kubernetes-mcp-server"]
+CMD ["--port", "8080"]
+EXPOSE 8080

--- a/hack/e2e/setup.sh
+++ b/hack/e2e/setup.sh
@@ -568,7 +568,7 @@ phase_deploy_oms() {
     phase "deploy-oms"
 
     step "Building openshift-mcp-server container image"
-    _run ${CONTAINER_CLI} build --load \
+    _run "${CONTAINER_CLI}" build --load \
         -f "${ROOT_DIR}/Containerfile.openshift-mcp-server" \
         -t "${OPENSHIFT_MCP_SERVER_IMAGE_REF}" "${ROOT_DIR}"
 

--- a/hack/e2e/setup.sh
+++ b/hack/e2e/setup.sh
@@ -69,7 +69,7 @@ _relativepath() {
 PHASE_DEFAULT="up"
 PROFILE="kind"
 STACKS="prometheus,tempo,loki"
-SUPPORTED_PHASES=(provision prereqs extras upload deploy run clean unprovision)
+SUPPORTED_PHASES=(provision prereqs extras upload deploy deploy-oms run clean unprovision)
 SUPPORTED_PROFILES=(kind k8s openshift)
 SUPPORTED_STACKS=(prometheus tempo loki)
 
@@ -390,45 +390,44 @@ EOF
     fi
 }
 
-phase_upload() {
-    phase "upload"
+_upload_image() {
+    local _image_name="$1"
+    local _image_ref="$2"
+    local _namespace="$3"
+    local _result
 
-    if [ -z "${IMAGE_REF:-}" ]; then
-        info "IMAGE_REF not set, skipping image upload."
-        return
-    fi
-
+    {
     case "${PROFILE}" in
         kind)
-            step "Loading obs-mcp image into Kind cluster '${KIND_CLUSTER_NAME}'"
+            step "Loading ${_image_name} image into Kind cluster '${KIND_CLUSTER_NAME}'"
             if [ "${CONTAINER_CLI}" == "podman" ]; then
                 mkdir -p "${ROOT_DIR}/tmp"
-                _run "${CONTAINER_CLI}" save --quiet -o "${ROOT_DIR}/tmp/obs-mcp.tar" "${IMAGE_REF}"
-                _run kind load image-archive --name "${KIND_CLUSTER_NAME}" "${ROOT_DIR}/tmp/obs-mcp.tar"
-                rm -f "${ROOT_DIR}/tmp/obs-mcp.tar"
+                _run "${CONTAINER_CLI}" save --quiet -o "${ROOT_DIR}/tmp/${_image_name}.tar" "${_image_ref}"
+                _run kind load image-archive --name "${KIND_CLUSTER_NAME}" "${ROOT_DIR}/tmp/${_image_name}.tar"
+                rm -f "${ROOT_DIR}/tmp/${_image_name}.tar"
             else
-                _run kind load docker-image --name "${KIND_CLUSTER_NAME}" "${IMAGE_REF}"
+                _run kind load docker-image --name "${KIND_CLUSTER_NAME}" "${_image_ref}"
             fi
-            _run kubectl delete pod -l app=obs-mcp --ignore-not-found=true
+            _result="${_image_ref}"
             ;;
         openshift)
-            step "Pushing obs-mcp image to OpenShift internal registry"
+            step "Pushing ${_image_name} image to OpenShift internal registry"
 
             if ! command -v skopeo >/dev/null; then
                 fail "skopeo is needed for the upload functionality to work"
             fi
 
-            # Derive the image tag from IMAGE_REF (use the tag portion, or fall back to 'latest')
+            # Derive the image tag from the ref (use the tag portion, or fall back to 'latest')
             local _img_tag
-            _img_tag=${IMAGE_REF##*:}
-            if [ "${_img_tag}" == "${IMAGE_REF}" ]; then
+            _img_tag=${_image_ref##*:}
+            if [ "${_img_tag}" == "${_image_ref}" ]; then
                # no substitution = tag not found, use latest;
                _img_tag="latest"
             fi
 
             # Ensure the target namespace exists (otherwise pushing an image fails with "denied")
-            if ! $KUBECTL get namespace obs-mcp &>/dev/null; then
-                _run $KUBECTL create namespace obs-mcp
+            if ! $KUBECTL get namespace "${_namespace}" &>/dev/null; then
+                _run $KUBECTL create namespace "${_namespace}"
             fi
 
             # Enable the default external route for the image registry (idempotent)
@@ -446,8 +445,8 @@ phase_upload() {
             # docker-archive: transport, which avoids the docker-daemon: transport's
             # hard-coded /var/tmp dependency (may not exist in all environments).
             local _tmp_tar
-            _tmp_tar=$(mktemp -t obs-mcp-XXXXXX.tar)
-            _run "${CONTAINER_CLI}" save "${IMAGE_REF}" -o "${_tmp_tar}"
+            _tmp_tar=$(mktemp -t "${_image_name}-XXXXXX.tar")
+            _run "${CONTAINER_CLI}" save "${_image_ref}" -o "${_tmp_tar}"
 
             # Copy directly with skopeo — no separate login or tag step needed.
             # The token is fed via an anonymous pipe (<(...)) so it never touches
@@ -458,17 +457,32 @@ phase_upload() {
                     "${_ext_registry}" \
                     "$(printf 'unused:%s' "$(oc whoami -t)" | base64 -w0)") \
                 "docker-archive:${_tmp_tar}" \
-                "docker://${_ext_registry}/obs-mcp/obs-mcp:${_img_tag}"
+                "docker://${_ext_registry}/${_namespace}/${_image_name}:${_img_tag}"
             rm -f "${_tmp_tar}"
 
-            # Override IMAGE_REF to the in-cluster registry address used by the deployment
-            IMAGE_REF="image-registry.openshift-image-registry.svc:5000/obs-mcp/obs-mcp:${_img_tag}"
-            info "Updated IMAGE_REF for deployment: ${IMAGE_REF}"
+            _result="image-registry.openshift-image-registry.svc:5000/${_namespace}/${_image_name}:${_img_tag}"
             ;;
         *)
             info "Image upload not supported for profile '${PROFILE}', skipping."
+            _result="${_image_ref}"
             ;;
     esac
+    } >&2
+
+    echo "${_result}"
+}
+
+phase_upload() {
+    phase "upload"
+
+    if [ -z "${IMAGE_REF:-}" ]; then
+        info "IMAGE_REF not set, skipping image upload."
+        return
+    fi
+
+    IMAGE_REF=$(_upload_image "obs-mcp" "${IMAGE_REF}" "obs-mcp")
+    info "Image ref for deployment: ${IMAGE_REF}"
+    _run kubectl delete pod -n obs-mcp -l app.kubernetes.io/name=obs-mcp --ignore-not-found=true
 }
 
 phase_deploy() {
@@ -545,6 +559,49 @@ EOF
 
     step "Waiting for obs-mcp rollout"
     _wait_rollout obs-mcp deployment/obs-mcp 3m
+}
+
+OPENSHIFT_MCP_SERVER_IMAGE_NAME="${OPENSHIFT_MCP_SERVER_IMAGE_NAME:-ghcr.io/rhobs/openshift-mcp-server}"
+OPENSHIFT_MCP_SERVER_IMAGE_REF="${OPENSHIFT_MCP_SERVER_IMAGE_REF:-${OPENSHIFT_MCP_SERVER_IMAGE_NAME}:${TAG:-latest}}"
+
+phase_deploy_oms() {
+    phase "deploy-oms"
+
+    step "Building openshift-mcp-server container image"
+    _run ${CONTAINER_CLI} build --load \
+        -f "${ROOT_DIR}/Containerfile.openshift-mcp-server" \
+        -t "${OPENSHIFT_MCP_SERVER_IMAGE_REF}" "${ROOT_DIR}"
+
+    OPENSHIFT_MCP_SERVER_IMAGE_REF=$(_upload_image "openshift-mcp-server" "${OPENSHIFT_MCP_SERVER_IMAGE_REF}" "openshift-mcp-server")
+    info "Image ref for deployment: ${OPENSHIFT_MCP_SERVER_IMAGE_REF}"
+    _run kubectl delete pod -n openshift-mcp-server -l app.kubernetes.io/name=openshift-mcp-server --ignore-not-found=true
+
+    step "Deploying openshift-mcp-server"
+    _overlay="${ROOT_DIR}/manifests/openshift-mcp-server/deploy/overlay"
+    mkdir -p "${_overlay}"
+    cat > "${_overlay}/kustomization.yaml" <<EOF
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../kubernetes
+patches:
+  - patch: |
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: openshift-mcp-server
+        namespace: openshift-mcp-server
+      spec:
+        template:
+          spec:
+            containers:
+              - name: openshift-mcp-server
+                image: "${OPENSHIFT_MCP_SERVER_IMAGE_REF}"
+EOF
+    _run $KUBECTL apply -k "${_overlay}"
+
+    step "Waiting for openshift-mcp-server rollout"
+    _wait_rollout openshift-mcp-server deployment/openshift-mcp-server 3m
 }
 
 phase_run() {
@@ -677,6 +734,7 @@ for phase in "${PHASES[@]}"; do
         extras)      phase_extras ;;
         upload)      phase_upload ;;
         deploy)      phase_deploy ;;
+        deploy-oms)  phase_deploy_oms ;;
         run)         phase_run ;;
         clean)       phase_clean ;;
         unprovision) phase_unprovision ;;

--- a/manifests/openshift-mcp-server/deploy/kubernetes/01_namespace.yaml
+++ b/manifests/openshift-mcp-server/deploy/kubernetes/01_namespace.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-mcp-server
+  labels:
+    kubernetes.io/metadata.name: openshift-mcp-server
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openshift-mcp-server

--- a/manifests/openshift-mcp-server/deploy/kubernetes/02_configmap.yaml
+++ b/manifests/openshift-mcp-server/deploy/kubernetes/02_configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openshift-mcp-server
+data:
+  config.toml: |
+    toolsets = ["observability/metrics", "observability/logs", "observability/traces", "observability/otelcol"]
+    experimental_enable_target_compatibility_tool_filters = true
+
+    [toolset_configs."observability/metrics"]
+    prometheus_url = "http://prometheus-k8s.monitoring.svc:9090"
+    alertmanager_url = "http://alertmanager-main.monitoring.svc:9093"

--- a/manifests/openshift-mcp-server/deploy/kubernetes/03_deployment.yaml
+++ b/manifests/openshift-mcp-server/deploy/kubernetes/03_deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: openshift-mcp-server
+  labels:
+    app.kubernetes.io/name: openshift-mcp-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: openshift-mcp-server
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: openshift-mcp-server
+    spec:
+      serviceAccountName: openshift-mcp-server
+      automountServiceAccountToken: true
+      containers:
+        - name: openshift-mcp-server
+          image: ghcr.io/rhobs/openshift-mcp-server:latest
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config
+            - /etc/openshift-mcp-server/config.toml
+            - --port
+            - "9100"
+            - --log-level
+            - "4"
+          ports:
+            - containerPort: 9100
+              name: mcp
+          volumeMounts:
+            - name: config
+              mountPath: /etc/openshift-mcp-server
+              readOnly: true
+          securityContext:
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: mcp
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: mcp
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      volumes:
+        - name: config
+          configMap:
+            name: openshift-mcp-server

--- a/manifests/openshift-mcp-server/deploy/kubernetes/04_service.yaml
+++ b/manifests/openshift-mcp-server/deploy/kubernetes/04_service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: openshift-mcp-server
+  labels:
+    app.kubernetes.io/name: openshift-mcp-server
+spec:
+  ports:
+    - name: mcp
+      port: 9100
+      targetPort: mcp
+  selector:
+    app.kubernetes.io/name: openshift-mcp-server

--- a/manifests/openshift-mcp-server/deploy/kubernetes/kustomization.yaml
+++ b/manifests/openshift-mcp-server/deploy/kubernetes/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openshift-mcp-server
+resources:
+  - 01_namespace.yaml
+  - 02_configmap.yaml
+  - 03_deployment.yaml
+  - 04_service.yaml


### PR DESCRIPTION
We should make it easier to test the tools with `openshift-mcp-server`, so I added a new `Containerfile` which builds the latest `openshift-mcp-server` and replaces the `github.com/rhobs/obs-mcp` dependency with the latest sources.

It's not a drop-in replacement:
* obs-mcp uses `/health`, openshift-mcp-server uses `/healthz` endpoint (we could converge here)
* CLI flags differ, i.e. the `Deployment` must be modified

I also added a basic e2e test for GitHub Actions.