### PR TITLE
RHOBS-1621: feat: add korrel8r MCP proxy to the server

### DIFF
--- a/cmd/obs-mcp/main.go
+++ b/cmd/obs-mcp/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/rhobs/obs-mcp/pkg/auth"
 	"github.com/rhobs/obs-mcp/pkg/k8s"
+	"github.com/rhobs/obs-mcp/pkg/korrel8r"
 	"github.com/rhobs/obs-mcp/pkg/logs"
 	mcpserver "github.com/rhobs/obs-mcp/pkg/mcp"
 	"github.com/rhobs/obs-mcp/pkg/otelcol"
@@ -60,6 +61,7 @@ func main() {
 	var tracesUseRoute = flag.Bool("traces.use-route", false, "Use Route instead of internal service DNS when connecting to Tempo API")
 	var lokiURL = flag.String("loki-url", "", "Loki API base URL (overrides LOKI_URL when explicitly set)")
 	var lokiUseRoute = flag.Bool("loki.use-route", false, "Use OpenShift Routes when discovering LokiStack endpoints")
+	var korrel8rURL = flag.String("korrel8r-url", "", "Korrel8r MCP server URL (overrides KORREL8R_URL when explicitly set)")
 	flag.Parse()
 
 	if *showVersion {
@@ -159,6 +161,21 @@ func main() {
 		tempoResolvedURL, tempoURLSource = determineTempoURL(*tempoURL)
 	}
 
+	// Determine Korrel8r URL only when korrel8r toolset is enabled.
+	korrel8rResolvedURL := ""
+	korrel8rURLSource := ""
+	var korrel8rConfig *korrel8r.Config
+	if slices.Contains(parsedToolsets, mcpserver.ToolsetKorrel8r) {
+		korrel8rResolvedURL, korrel8rURLSource = determineKorrel8rURL(*korrel8rURL)
+		if korrel8rResolvedURL == "" {
+			log.Fatalf("--korrel8r-url or KORREL8R_URL must be set when korrel8r toolset is enabled")
+		}
+		korrel8rConfig = &korrel8r.Config{
+			Endpoint: korrel8rResolvedURL,
+			Insecure: *insecure,
+		}
+	}
+
 	// Create MCP options
 	opts := mcpserver.ObsMCPOptions{
 		Toolsets:               parsedToolsets,
@@ -181,10 +198,13 @@ func main() {
 			LokiURL:  lokiResolvedURL,
 			UseRoute: *lokiUseRoute,
 		},
+		Korrel8r: korrel8rConfig,
 	}
 
+	ctx := context.Background()
+
 	// Create MCP server
-	mcpServer, err := mcpserver.NewMCPServer(opts)
+	mcpServer, err := mcpserver.NewMCPServer(ctx, opts)
 	if err != nil {
 		log.Fatalf("Failed to create MCP server: %v", err)
 	}
@@ -200,6 +220,8 @@ func main() {
 		"loki_url_source", lokiURLSource,
 		"tempo_url", tempoResolvedURL,
 		"tempo_url_source", tempoURLSource,
+		"korrel8r_url", korrel8rResolvedURL,
+		"korrel8r_url_source", korrel8rURLSource,
 		"guardrails", opts.Guardrails,
 	)
 
@@ -317,6 +339,16 @@ func determineLokiURL(authMode auth.AuthMode, flagURL string, useRoute bool) (ur
 	}
 	slog.Warn("No Loki URL configured; Loki tools require lokiNamespace+lokiName discovery parameters or explicit Loki URL")
 	return "", "unset", nil
+}
+
+func determineKorrel8rURL(flagURL string) (url, source string) {
+	if flagURL != "" {
+		return flagURL, "--korrel8r-url flag"
+	}
+	if u := os.Getenv("KORREL8R_URL"); u != "" {
+		return u, "KORREL8R_URL env var"
+	}
+	return "", "unset"
 }
 
 // isFlagExplicitlySet reports whether the named flag was explicitly provided on

--- a/pkg/korrel8r/korrel8r.go
+++ b/pkg/korrel8r/korrel8r.go
@@ -1,0 +1,138 @@
+// Package korrel8r provides an MCP forwarding proxy to a remote korrel8r MCP server.
+// It discovers tools dynamically at startup and forwards all calls transparently,
+// preserving instructions, tool descriptions, and schemas identically.
+package korrel8r
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+type Config struct {
+	Endpoint string
+	Insecure bool
+}
+
+// Proxy connects to a remote korrel8r MCP server and forwards tool calls to it.
+type Proxy struct {
+	cs           *mcp.ClientSession
+	tools        []*mcp.Tool
+	instructions string
+}
+
+// Connect creates a proxy by connecting to the remote korrel8r MCP server,
+// discovering its tools, and capturing its instructions.
+func Connect(ctx context.Context, cfg *Config) (*Proxy, error) {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	if cfg.Insecure {
+		transport.TLSClientConfig = &tls.Config{
+			MinVersion:         tls.VersionTLS12,
+			InsecureSkipVerify: true,
+		}
+	}
+	httpClient := &http.Client{
+		Transport: &authRoundTripper{next: transport},
+	}
+
+	client := mcp.NewClient(
+		&mcp.Implementation{Name: "obs-mcp-korrel8r-proxy", Version: "1.0.0"},
+		nil,
+	)
+	cs, err := client.Connect(ctx, &mcp.StreamableClientTransport{
+		Endpoint:             cfg.Endpoint,
+		HTTPClient:           httpClient,
+		DisableStandaloneSSE: true,
+	}, nil)
+	if err != nil {
+		return nil, fmt.Errorf("connecting to korrel8r MCP server: %w", err)
+	}
+
+	tools, err := cs.ListTools(ctx, &mcp.ListToolsParams{})
+	if err != nil {
+		_ = cs.Close()
+		return nil, fmt.Errorf("listing korrel8r tools: %w", err)
+	}
+
+	return &Proxy{
+		cs:           cs,
+		tools:        tools.Tools,
+		instructions: cs.InitializeResult().Instructions,
+	}, nil
+}
+
+// Instructions returns the instructions from the remote korrel8r server.
+func (p *Proxy) Instructions() string {
+	return p.instructions
+}
+
+// AddTools registers all discovered tools on the MCP server with forwarding handlers.
+func (p *Proxy) AddTools(mcpServer *mcp.Server) {
+	for _, t := range p.tools {
+		mcpServer.AddTool(t, forwardHandler(p.cs, t.Name))
+	}
+}
+
+// Close closes the connection to the remote server.
+func (p *Proxy) Close() {
+	if p.cs != nil {
+		_ = p.cs.Close()
+	}
+}
+
+// forwardHandler returns a ToolHandler that forwards the call to the remote server.
+func forwardHandler(cs *mcp.ClientSession, name string) mcp.ToolHandler {
+	return func(ctx context.Context, req *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		if req.Extra != nil && req.Extra.Header != nil {
+			if authHeader := req.Extra.Header.Get("Authorization"); authHeader != "" {
+				if token, ok := strings.CutPrefix(authHeader, "Bearer "); ok {
+					ctx = withToken(ctx, token)
+				}
+			}
+		}
+
+		var args map[string]any
+		if len(req.Params.Arguments) > 0 {
+			if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
+				return nil, err
+			}
+		}
+
+		return cs.CallTool(ctx, &mcp.CallToolParams{
+			Name:      name,
+			Arguments: args,
+		})
+	}
+}
+
+type tokenKey struct{}
+
+func withToken(ctx context.Context, token string) context.Context {
+	if token == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, tokenKey{}, token)
+}
+
+func tokenFromContext(ctx context.Context) string {
+	token, _ := ctx.Value(tokenKey{}).(string)
+	return token
+}
+
+// authRoundTripper forwards bearer tokens from context to outgoing HTTP requests.
+type authRoundTripper struct {
+	next http.RoundTripper
+}
+
+func (rt *authRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if token := tokenFromContext(req.Context()); token != "" {
+		req = req.Clone(req.Context())
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	return rt.next.RoundTrip(req)
+}

--- a/pkg/korrel8r/korrel8r_test.go
+++ b/pkg/korrel8r/korrel8r_test.go
@@ -1,0 +1,201 @@
+package korrel8r
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testInstructions = "Test instructions for korrel8r proxy."
+
+// newMockUpstream creates a mock korrel8r MCP server with a few tools.
+func newMockUpstream(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := mcp.NewServer(
+		&mcp.Implementation{Name: "mock-korrel8r", Version: "1.0.0"},
+		&mcp.ServerOptions{Instructions: testInstructions},
+	)
+
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "list_domains",
+		Description: "List available domains.",
+	}, func(_ context.Context, _ *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
+		return nil, map[string]any{"domains": []map[string]any{{"name": "mock"}}}, nil
+	})
+
+	type domainInput struct {
+		Domain string `json:"domain"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "list_domain_classes",
+		Description: "List classes in a domain.",
+	}, func(_ context.Context, _ *mcp.CallToolRequest, input domainInput) (*mcp.CallToolResult, any, error) {
+		if input.Domain != "mock" {
+			return &mcp.CallToolResult{IsError: true, Content: []mcp.Content{&mcp.TextContent{Text: "unknown domain"}}}, nil, nil
+		}
+		return nil, map[string]any{"domain": "mock", "classes": []string{"a", "b"}}, nil
+	})
+
+	type helpInput struct {
+		Domain string `json:"domain,omitempty"`
+	}
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "help",
+		Description: "Get help about domains.",
+	}, func(_ context.Context, _ *mcp.CallToolRequest, input helpInput) (*mcp.CallToolResult, any, error) {
+		return nil, map[string]any{"documentation": "mock help for " + input.Domain}, nil
+	})
+
+	handler := mcp.NewStreamableHTTPHandler(func(_ *http.Request) *mcp.Server {
+		return server
+	}, &mcp.StreamableHTTPOptions{Stateless: true})
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// newProxyClient sets up a proxy to the mock upstream and returns a client session.
+func newProxyClient(t *testing.T) *mcp.ClientSession {
+	t.Helper()
+	ctx := context.Background()
+
+	upstream := newMockUpstream(t)
+	proxy, err := Connect(ctx, &Config{Endpoint: upstream.URL})
+	require.NoError(t, err)
+	t.Cleanup(proxy.Close)
+
+	proxyServer := mcp.NewServer(
+		&mcp.Implementation{Name: "test-proxy", Version: "1.0.0"},
+		&mcp.ServerOptions{Instructions: proxy.Instructions()},
+	)
+	proxy.AddTools(proxyServer)
+
+	ct, st := mcp.NewInMemoryTransports()
+	ss, err := proxyServer.Connect(ctx, st, nil)
+	require.NoError(t, err)
+	c := mcp.NewClient(&mcp.Implementation{Name: "test-client"}, nil)
+	cs, err := c.Connect(ctx, ct, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cs.Close(); _ = ss.Wait() })
+	return cs
+}
+
+func TestProxyListTools(t *testing.T) {
+	cs := newProxyClient(t)
+	tools, err := cs.ListTools(context.Background(), &mcp.ListToolsParams{})
+	require.NoError(t, err)
+	var names []string
+	for _, tool := range tools.Tools {
+		names = append(names, tool.Name)
+	}
+	assert.ElementsMatch(t, names, []string{"list_domains", "list_domain_classes", "help"})
+}
+
+func TestProxyListDomains(t *testing.T) {
+	cs := newProxyClient(t)
+	r, err := cs.CallTool(context.Background(), &mcp.CallToolParams{Name: "list_domains"})
+	require.NoError(t, err)
+	require.False(t, r.IsError)
+	got := r.StructuredContent.(map[string]any)
+	domains := got["domains"].([]any)
+	require.Len(t, domains, 1)
+	assert.Equal(t, "mock", domains[0].(map[string]any)["name"])
+}
+
+func TestProxyListDomainClasses(t *testing.T) {
+	cs := newProxyClient(t)
+	r, err := cs.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "list_domain_classes",
+		Arguments: map[string]any{"domain": "mock"},
+	})
+	require.NoError(t, err)
+	require.False(t, r.IsError)
+	got := r.StructuredContent.(map[string]any)
+	assert.Equal(t, "mock", got["domain"])
+	assert.Equal(t, []any{"a", "b"}, got["classes"])
+}
+
+func TestProxyToolError(t *testing.T) {
+	cs := newProxyClient(t)
+	r, err := cs.CallTool(context.Background(), &mcp.CallToolParams{
+		Name:      "list_domain_classes",
+		Arguments: map[string]any{"domain": "nosuch"},
+	})
+	require.NoError(t, err)
+	assert.True(t, r.IsError)
+}
+
+func TestProxyInstructions(t *testing.T) {
+	cs := newProxyClient(t)
+	assert.Equal(t, testInstructions, cs.InitializeResult().Instructions)
+}
+
+func TestProxyToolDescriptionsAndSchemas(t *testing.T) {
+	ctx := context.Background()
+
+	// Connect directly to the upstream.
+	upstream := newMockUpstream(t)
+	directClient := mcp.NewClient(&mcp.Implementation{Name: "direct"}, nil)
+	directCS, err := directClient.Connect(ctx, &mcp.StreamableClientTransport{
+		Endpoint: upstream.URL, DisableStandaloneSSE: true,
+	}, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = directCS.Close() })
+	directTools, err := directCS.ListTools(ctx, &mcp.ListToolsParams{})
+	require.NoError(t, err)
+
+	// Connect via proxy.
+	proxy, err := Connect(ctx, &Config{Endpoint: upstream.URL})
+	require.NoError(t, err)
+	t.Cleanup(proxy.Close)
+	proxyServer := mcp.NewServer(
+		&mcp.Implementation{Name: "test-proxy", Version: "1.0.0"},
+		&mcp.ServerOptions{Instructions: proxy.Instructions()},
+	)
+	proxy.AddTools(proxyServer)
+	ct, st := mcp.NewInMemoryTransports()
+	ss, err := proxyServer.Connect(ctx, st, nil)
+	require.NoError(t, err)
+	proxyClient := mcp.NewClient(&mcp.Implementation{Name: "proxy-client"}, nil)
+	proxyCS, err := proxyClient.Connect(ctx, ct, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = proxyCS.Close(); _ = ss.Wait() })
+	proxyTools, err := proxyCS.ListTools(ctx, &mcp.ListToolsParams{})
+	require.NoError(t, err)
+
+	require.Equal(t, len(directTools.Tools), len(proxyTools.Tools))
+
+	directByName := map[string]*mcp.Tool{}
+	for _, tool := range directTools.Tools {
+		directByName[tool.Name] = tool
+	}
+	proxyByName := map[string]*mcp.Tool{}
+	for _, tool := range proxyTools.Tools {
+		proxyByName[tool.Name] = tool
+	}
+
+	for name, direct := range directByName {
+		proxied, ok := proxyByName[name]
+		require.True(t, ok, "proxy missing tool %s", name)
+		assert.Equal(t, direct.Description, proxied.Description, "description mismatch for %s", name)
+
+		directSchema, err := json.Marshal(direct.InputSchema)
+		require.NoError(t, err)
+		proxySchema, err := json.Marshal(proxied.InputSchema)
+		require.NoError(t, err)
+		assert.JSONEq(t, string(directSchema), string(proxySchema), "input schema mismatch for %s", name)
+
+		if direct.OutputSchema != nil {
+			require.NotNil(t, proxied.OutputSchema, "proxy missing output schema for %s", name)
+			directOut, _ := json.Marshal(direct.OutputSchema)
+			proxyOut, _ := json.Marshal(proxied.OutputSchema)
+			assert.JSONEq(t, string(directOut), string(proxyOut), "output schema mismatch for %s", name)
+		}
+	}
+}

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -19,6 +20,7 @@ import (
 
 	"github.com/rhobs/obs-mcp/pkg/auth"
 	"github.com/rhobs/obs-mcp/pkg/k8s"
+	"github.com/rhobs/obs-mcp/pkg/korrel8r"
 	"github.com/rhobs/obs-mcp/pkg/logs"
 	"github.com/rhobs/obs-mcp/pkg/otelcol"
 	"github.com/rhobs/obs-mcp/pkg/prometheus"
@@ -32,10 +34,11 @@ const (
 	ToolsetMetrics Toolset = "observability/metrics"
 	ToolsetTraces  Toolset = "observability/traces"
 	ToolsetLogs    Toolset = "observability/logs"
-	ToolsetOtelcol Toolset = "observability/otelcol"
+	ToolsetOtelcol   Toolset = "observability/otelcol"
+	ToolsetKorrel8r  Toolset = "observability/korrel8r"
 )
 
-var AllToolsets = []string{string(ToolsetMetrics), string(ToolsetTraces), string(ToolsetLogs), string(ToolsetOtelcol)}
+var AllToolsets = []string{string(ToolsetMetrics), string(ToolsetTraces), string(ToolsetLogs), string(ToolsetOtelcol), string(ToolsetKorrel8r)}
 
 // ObsMCPOptions contains configuration options for the MCP server
 type ObsMCPOptions struct {
@@ -49,6 +52,7 @@ type ObsMCPOptions struct {
 	Traces                 *traces.Config
 	Otelcol                *otelcol.Config
 	Logs                   *logs.Config
+	Korrel8r               *korrel8r.Config
 }
 
 const (
@@ -59,7 +63,7 @@ const (
 	defaultShutdownTimeout = 10 * time.Second
 )
 
-func NewMCPServer(opts ObsMCPOptions) (*mcp.Server, error) {
+func NewMCPServer(ctx context.Context, opts ObsMCPOptions) (*mcp.Server, error) {
 	impl := &mcp.Implementation{
 		Name:    serverName,
 		Version: serverVersion,
@@ -79,11 +83,28 @@ func NewMCPServer(opts ObsMCPOptions) (*mcp.Server, error) {
 		instructions = append(instructions, otelcol.ServerPrompt)
 	}
 
+	var korrel8rProxy *korrel8r.Proxy
+	if slices.Contains(opts.Toolsets, ToolsetKorrel8r) {
+		if opts.Korrel8r == nil {
+			return nil, errors.New("configuration for korrel8r toolset is missing")
+		}
+		proxy, err := korrel8r.Connect(ctx, opts.Korrel8r)
+		if err != nil {
+			return nil, fmt.Errorf("korrel8r proxy: %w", err)
+		}
+		korrel8rProxy = proxy
+		instructions = append(instructions, proxy.Instructions())
+	}
+
 	serverOpts := &mcp.ServerOptions{
 		Instructions: strings.Join(instructions, "\n"),
 	}
 
 	mcpServer := mcp.NewServer(impl, serverOpts)
+
+	if korrel8rProxy != nil {
+		korrel8rProxy.AddTools(mcpServer)
+	}
 
 	if err := SetupTools(mcpServer, opts); err != nil {
 		return nil, err


### PR DESCRIPTION
Adds a proxy to the Korrel8r MCP server as a toolset.
The proxy forwards Authentication tokens as required by korrel8r,
and proxies remote tool calls,
and returns instructions, tool list, tool and schema descriptions from the remote server.