### PR TITLE
feat: hide traces tools if Tempo CRD is not installed

### DIFF
--- a/pkg/traces/common.go
+++ b/pkg/traces/common.go
@@ -1,6 +1,7 @@
 package traces
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -9,12 +10,19 @@ import (
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/google/jsonschema-go/jsonschema"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/rhobs/obs-mcp/pkg/auth"
 	"github.com/rhobs/obs-mcp/pkg/prometheus"
 	"github.com/rhobs/obs-mcp/pkg/traces/discovery"
 	tempoclient "github.com/rhobs/obs-mcp/pkg/traces/tempo"
 )
+
+var tempoStackGVK = schema.GroupVersionKind{
+	Group:   "tempo.grafana.com",
+	Version: "v1alpha1",
+	Kind:    "TempoStack",
+}
 
 var (
 	tempoNamespaceSchema = &jsonschema.Schema{
@@ -30,6 +38,14 @@ var (
 		Description: "The tenant to query. This parameter is required for multi-tenant instances. Use tempo_list_instances to discover available tenants for each instance.",
 	}
 )
+
+func hasTempoStackCRD(p api.FilteringProvider) func() bool {
+	return func() bool {
+		return p.AnyTargetHasGVKs(context.TODO(), []schema.GroupVersionKind{
+			tempoStackGVK,
+		})
+	}
+}
 
 // getTempoClient returns a Tempo client based on the config and tempoNamespace, tempoName and tenant parameters.
 // When a static TempoURL is configured, it is used directly without discovery.

--- a/pkg/traces/get_trace_by_id.go
+++ b/pkg/traces/get_trace_by_id.go
@@ -18,7 +18,7 @@ type getTraceByIDOutput struct {
 
 var getTraceByIDOutputSchema = tools.MustSchema[getTraceByIDOutput]()
 
-func initGetTraceByID() api.ServerTool {
+func initGetTraceByID(p api.FilteringProvider) api.ServerTool {
 	return api.ServerTool{
 		Tool: api.Tool{
 			Name: "tempo_get_trace_by_id",
@@ -58,6 +58,9 @@ Narrows the time range to improve query performance.`,
 			},
 		},
 		Handler: getTraceByIDHandler,
+		TargetCompatibilityFilters: []func() bool{
+			hasTempoStackCRD(p),
+		},
 	}
 }
 

--- a/pkg/traces/list_instances.go
+++ b/pkg/traces/list_instances.go
@@ -15,7 +15,7 @@ type listInstancesOutput struct {
 
 var listInstancesOutputSchema = tools.MustSchema[listInstancesOutput]()
 
-func initListInstances() api.ServerTool {
+func initListInstances(p api.FilteringProvider) api.ServerTool {
 	return api.ServerTool{
 		Tool: api.Tool{
 			Name: "tempo_list_instances",
@@ -36,6 +36,9 @@ Always print the output of this tool in a table.`,
 			},
 		},
 		Handler: listInstancesHandler,
+		TargetCompatibilityFilters: []func() bool{
+			hasTempoStackCRD(p),
+		},
 	}
 }
 

--- a/pkg/traces/search_tag_values.go
+++ b/pkg/traces/search_tag_values.go
@@ -18,7 +18,7 @@ type searchTagValuesOutput struct {
 
 var searchTagValuesOutputSchema = tools.MustSchema[searchTagValuesOutput]()
 
-func initSearchTagValues() api.ServerTool {
+func initSearchTagValues(p api.FilteringProvider) api.ServerTool {
 	return api.ServerTool{
 		Tool: api.Tool{
 			Name: "tempo_search_tag_values",
@@ -70,6 +70,9 @@ e.g. '{ resource.service.name="payment-service" }' to only show tag values from 
 			},
 		},
 		Handler: searchTagValuesHandler,
+		TargetCompatibilityFilters: []func() bool{
+			hasTempoStackCRD(p),
+		},
 	}
 }
 

--- a/pkg/traces/search_tags.go
+++ b/pkg/traces/search_tags.go
@@ -18,7 +18,7 @@ type searchTagsOutput struct {
 
 var searchTagsOutputSchema = tools.MustSchema[searchTagsOutput]()
 
-func initSearchTags() api.ServerTool {
+func initSearchTags(p api.FilteringProvider) api.ServerTool {
 	return api.ServerTool{
 		Tool: api.Tool{
 			Name: "tempo_search_tags",
@@ -74,6 +74,9 @@ e.g. '{ resource.service.name="payment-service" }' to only show tags present in 
 			},
 		},
 		Handler: searchTagsHandler,
+		TargetCompatibilityFilters: []func() bool{
+			hasTempoStackCRD(p),
+		},
 	}
 }
 

--- a/pkg/traces/search_traces.go
+++ b/pkg/traces/search_traces.go
@@ -19,7 +19,7 @@ type searchTracesOutput struct {
 
 var searchTracesOutputSchema = tools.MustSchema[searchTracesOutput]()
 
-func initSearchTraces() api.ServerTool {
+func initSearchTraces(p api.FilteringProvider) api.ServerTool {
 	return api.ServerTool{
 		Tool: api.Tool{
 			Name: "tempo_search_traces",
@@ -122,6 +122,9 @@ Both start and end should be provided to search the full time range; if omitted,
 			},
 		},
 		Handler: searchTracesHandler,
+		TargetCompatibilityFilters: []func() bool{
+			hasTempoStackCRD(p),
+		},
 	}
 }
 

--- a/pkg/traces/toolset.go
+++ b/pkg/traces/toolset.go
@@ -22,13 +22,13 @@ func (t *Toolset) GetDescription() string {
 }
 
 // GetTools returns all tools provided by this toolset.
-func (t *Toolset) GetTools(_ api.FilteringProvider) []api.ServerTool {
+func (t *Toolset) GetTools(p api.FilteringProvider) []api.ServerTool {
 	return []api.ServerTool{
-		initListInstances(),
-		initGetTraceByID(),
-		initSearchTraces(),
-		initSearchTags(),
-		initSearchTagValues(),
+		initListInstances(p),
+		initGetTraceByID(p),
+		initSearchTraces(p),
+		initSearchTags(p),
+		initSearchTagValues(p),
 	}
 }
 


### PR DESCRIPTION
Utilize the new `TargetCompatibilityFilters` API to hide traces tools if Tempo CRD is not installed (i.e., the Tempo operator is not installed).