### PR TITLE
feat: scaffold observability/alert-management toolset

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -64,6 +64,7 @@ This MCP server exposes the following tools for Prometheus/Thanos, Alertmanager,
   - [`otelcol_get_component_schema`](#otelcol_get_component_schema)
   - [`otelcol_validate_config`](#otelcol_validate_config)
   - [`otelcol_get_versions`](#otelcol_get_versions)
+- **🛡️ [Alert Management](#alert-management)** (0 tools)
 
 ---
 
@@ -875,4 +876,10 @@ _No parameters._
 | `versions` | `string[]` | List of available OpenTelemetry Collector versions |
 
 </details>
+
+---
+
+<a id="alert-management"></a>
+
+## 🛡️ Alert Management
 

--- a/cmd/obs-mcp/main.go
+++ b/cmd/obs-mcp/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/prometheus/common/promslog"
 	"github.com/prometheus/common/version"
 
+	"github.com/rhobs/obs-mcp/pkg/alertmanagement"
 	"github.com/rhobs/obs-mcp/pkg/auth"
 	"github.com/rhobs/obs-mcp/pkg/health"
 	"github.com/rhobs/obs-mcp/pkg/k8s"
@@ -36,6 +37,7 @@ const (
 	defaultPrometheusURL   = "http://localhost:9090"
 	defaultAlertmanagerURL = "http://localhost:9093"
 	defaultLokiURL         = "http://localhost:3100"
+	defaultAlertMgmtAPIURL = "http://localhost:9444"
 )
 
 func main() { //nolint:gocyclo // main wires up flags, config, and run group
@@ -66,6 +68,7 @@ func main() { //nolint:gocyclo // main wires up flags, config, and run group
 	var tracesUseRoute = flag.Bool("traces.use-route", false, "Use Route instead of internal service DNS when connecting to Tempo API")
 	var lokiURL = flag.String("loki-url", "", "Loki API base URL (overrides LOKI_URL when explicitly set)")
 	var lokiUseRoute = flag.Bool("loki.use-route", false, "Use OpenShift Routes when discovering LokiStack endpoints")
+	var alertMgmtAPIURL = flag.String("alert-mgmt-api-url", "", "Monitoring-plugin alert management API base URL (overrides ALERT_MGMT_API_URL when explicitly set)")
 	flag.Parse()
 
 	if *showVersion {
@@ -131,6 +134,13 @@ func main() { //nolint:gocyclo // main wires up flags, config, and run group
 		}
 	}
 
+	// Determine alert management API URL only when alert-management toolset is enabled.
+	alertMgmtResolvedURL := ""
+	alertMgmtURLSource := ""
+	if slices.Contains(parsedToolsets, mcpserver.ToolsetAlertManagement) {
+		alertMgmtResolvedURL, alertMgmtURLSource = determineAlertMgmtAPIURL(*alertMgmtAPIURL)
+	}
+
 	// Parse guardrails configuration
 	parsedGuardrails, err := prometheus.ParseGuardrails(*guardrails)
 	if err != nil {
@@ -188,6 +198,11 @@ func main() { //nolint:gocyclo // main wires up flags, config, and run group
 			UseRoute: *tracesUseRoute,
 		},
 		Otelcol: otelcol.NewDefaultConfig(),
+		AlertManagement: &alertmanagement.Config{
+			AuthMode:         parsedAuthMode,
+			ManagementAPIURL: alertMgmtResolvedURL,
+			Insecure:         *insecure,
+		},
 		Logs: &logs.Config{
 			AuthMode: parsedAuthMode,
 			Insecure: *insecure,
@@ -216,6 +231,8 @@ func main() { //nolint:gocyclo // main wires up flags, config, and run group
 		"loki_url_source", lokiURLSource,
 		"tempo_url", tempoResolvedURL,
 		"tempo_url_source", tempoURLSource,
+		"alert_mgmt_api_url", alertMgmtResolvedURL,
+		"alert_mgmt_api_url_source", alertMgmtURLSource,
 		"guardrails", opts.Guardrails,
 	)
 
@@ -407,6 +424,17 @@ func isFlagExplicitlySet(name string) bool {
 		}
 	})
 	return found
+}
+
+func determineAlertMgmtAPIURL(flagURL string) (url, source string) {
+	if flagURL != "" {
+		return flagURL, "--alert-mgmt-api-url flag"
+	}
+	if envURL := os.Getenv("ALERT_MGMT_API_URL"); envURL != "" {
+		return envURL, "ALERT_MGMT_API_URL env var"
+	}
+	slog.Warn("No alert management API URL configured, falling back to default", "default", defaultAlertMgmtAPIURL)
+	return defaultAlertMgmtAPIURL, "default"
 }
 
 // configureLogging sets up the slog logger with the specified log level

--- a/pkg/alertmanagement/config.go
+++ b/pkg/alertmanagement/config.go
@@ -1,0 +1,68 @@
+package alertmanagement
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/BurntSushi/toml"
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+	serverconfig "github.com/containers/kubernetes-mcp-server/pkg/config"
+
+	"github.com/rhobs/obs-mcp/pkg/auth"
+)
+
+func init() {
+	serverconfig.RegisterToolsetConfig(ToolsetName, alertManagementToolsetParser)
+}
+
+// Config holds alert management toolset configuration.
+type Config struct {
+	// AuthMode controls where the bearer token is obtained for authenticating
+	// against the monitoring-plugin management API.
+	AuthMode auth.AuthMode `toml:"auth_mode,omitempty"`
+
+	// ManagementAPIURL is the base URL of the monitoring-plugin management API.
+	ManagementAPIURL string `toml:"management_api_url,omitempty"`
+
+	// Insecure controls whether to skip TLS certificate verification.
+	Insecure bool `toml:"insecure,omitempty"`
+}
+
+var _ api.ExtendedConfig = (*Config)(nil)
+
+var DefaultConfig = &Config{}
+
+func (c *Config) Validate() error {
+	if c.AuthMode != "" && c.AuthMode != auth.AuthModeHeader && c.AuthMode != auth.AuthModeKubeConfig {
+		return fmt.Errorf("invalid auth_mode: %q (valid options: %q, %q)", c.AuthMode, auth.AuthModeHeader, auth.AuthModeKubeConfig)
+	}
+	return nil
+}
+
+func (c *Config) GetAuthMode() auth.AuthMode {
+	if c.AuthMode == "" {
+		return auth.AuthModeHeader
+	}
+	return c.AuthMode
+}
+
+func alertManagementToolsetParser(_ context.Context, primitive toml.Primitive, md toml.MetaData) (api.ExtendedConfig, error) {
+	var cfg Config
+	if err := md.PrimitiveDecode(primitive, &cfg); err != nil {
+		return nil, err
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+// GetConfig retrieves the alert management toolset configuration from params.
+func GetConfig(params api.ToolHandlerParams) *Config {
+	if cfg, ok := params.GetToolsetConfig(ToolsetName); ok {
+		if amCfg, ok := cfg.(*Config); ok {
+			return amCfg
+		}
+	}
+	return DefaultConfig
+}

--- a/pkg/alertmanagement/prompt.go
+++ b/pkg/alertmanagement/prompt.go
@@ -1,0 +1,15 @@
+package alertmanagement
+
+// ServerPrompt provides instructions for LLMs using the alert management toolset.
+const ServerPrompt = `
+## Alert Rule Management Workflow
+
+This toolset manages OpenShift alert rules via the monitoring-plugin management API.
+It supports both in-console (Lightspeed) and non-console (Cursor, Claude, CLI) usage.
+
+When managing alert rules:
+1. List existing rules first to understand the current state
+2. Respect RBAC boundaries — operations are scoped to the user's permissions
+3. Do not attempt to modify GitOps-managed or operator-managed rules
+4. Use standard severity levels: critical, warning, info, none
+5. Provide clear PromQL expressions — validate syntax before creating rules`

--- a/pkg/alertmanagement/toolset.go
+++ b/pkg/alertmanagement/toolset.go
@@ -1,0 +1,39 @@
+package alertmanagement
+
+import (
+	"github.com/containers/kubernetes-mcp-server/pkg/api"
+)
+
+const ToolsetName = "observability/alert-management"
+
+// Toolset implements the alert management toolset backed by the
+// monitoring-plugin management API.
+type Toolset struct{}
+
+var _ api.Toolset = (*Toolset)(nil)
+
+func (t *Toolset) GetName() string {
+	return ToolsetName
+}
+
+func (t *Toolset) GetDescription() string {
+	return "Toolset for managing OpenShift alert rules via the monitoring-plugin management API."
+}
+
+// GetTools returns all tools provided by this toolset.
+// Tools will be added as the monitoring-plugin management API endpoints land.
+func (t *Toolset) GetTools(_ api.FilteringProvider) []api.ServerTool {
+	return []api.ServerTool{}
+}
+
+func (t *Toolset) GetPrompts() []api.ServerPrompt {
+	return nil
+}
+
+func (t *Toolset) GetResources() []api.ServerResource {
+	return nil
+}
+
+func (t *Toolset) GetResourceTemplates() []api.ServerResourceTemplate {
+	return nil
+}

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	prom "github.com/prometheus/client_golang/prometheus"
 
+	"github.com/rhobs/obs-mcp/pkg/alertmanagement"
 	"github.com/rhobs/obs-mcp/pkg/auth"
 	"github.com/rhobs/obs-mcp/pkg/instrumentation"
 	"github.com/rhobs/obs-mcp/pkg/k8s"
@@ -28,13 +29,14 @@ import (
 type Toolset string
 
 const (
-	ToolsetMetrics Toolset = "observability/metrics"
-	ToolsetTraces  Toolset = "observability/traces"
-	ToolsetLogs    Toolset = "observability/logs"
-	ToolsetOtelcol Toolset = "observability/otelcol"
+	ToolsetMetrics         Toolset = "observability/metrics"
+	ToolsetTraces          Toolset = "observability/traces"
+	ToolsetLogs            Toolset = "observability/logs"
+	ToolsetOtelcol         Toolset = "observability/otelcol"
+	ToolsetAlertManagement Toolset = "observability/alert-management"
 )
 
-var AllToolsets = []string{string(ToolsetMetrics), string(ToolsetTraces), string(ToolsetLogs), string(ToolsetOtelcol)}
+var AllToolsets = []string{string(ToolsetMetrics), string(ToolsetTraces), string(ToolsetLogs), string(ToolsetOtelcol), string(ToolsetAlertManagement)}
 
 // ObsMCPOptions contains configuration options for the MCP server
 type ObsMCPOptions struct {
@@ -48,6 +50,7 @@ type ObsMCPOptions struct {
 	Traces                 *traces.Config
 	Otelcol                *otelcol.Config
 	Logs                   *logs.Config
+	AlertManagement        *alertmanagement.Config
 	Registry               prom.Registerer
 	clientMetrics          *instrumentation.ClientMetrics
 	toolMetrics            *instrumentation.ToolMetrics
@@ -89,6 +92,9 @@ func NewMCPServer(opts ObsMCPOptions) (*mcp.Server, error) {
 	if slices.Contains(opts.Toolsets, ToolsetOtelcol) {
 		instructions = append(instructions, otelcol.ServerPrompt)
 	}
+	if slices.Contains(opts.Toolsets, ToolsetAlertManagement) {
+		instructions = append(instructions, alertmanagement.ServerPrompt)
+	}
 
 	serverOpts := &mcp.ServerOptions{
 		Instructions: strings.Join(instructions, "\n"),
@@ -105,7 +111,7 @@ func NewMCPServer(opts ObsMCPOptions) (*mcp.Server, error) {
 
 func needsKubernetes(toolsets []Toolset) bool {
 	for _, ts := range toolsets {
-		if ts == ToolsetTraces || ts == ToolsetLogs || ts == ToolsetOtelcol {
+		if ts == ToolsetTraces || ts == ToolsetLogs || ts == ToolsetOtelcol || ts == ToolsetAlertManagement {
 			return true
 		}
 	}
@@ -176,6 +182,16 @@ func SetupTools(mcpServer *mcp.Server, opts ObsMCPOptions) error {
 		}
 		opts.Logs.ClientMetrics = opts.clientMetrics
 		err := addToolset(mcpServer, mgr, &logs.Toolset{}, opts.Logs, opts.toolMetrics)
+		if err != nil {
+			return err
+		}
+	}
+
+	if slices.Contains(opts.Toolsets, ToolsetAlertManagement) {
+		if opts.AlertManagement == nil {
+			return errors.New("configuration for alert-management toolset is missing")
+		}
+		err := addToolset(mcpServer, mgr, &alertmanagement.Toolset{}, opts.AlertManagement, opts.toolMetrics)
 		if err != nil {
 			return err
 		}

--- a/pkg/mcp/tools.go
+++ b/pkg/mcp/tools.go
@@ -4,6 +4,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/rhobs/obs-mcp/pkg/alertmanagement"
 	"github.com/rhobs/obs-mcp/pkg/logs"
 	tools "github.com/rhobs/obs-mcp/pkg/metrics"
 	"github.com/rhobs/obs-mcp/pkg/otelcol"
@@ -54,6 +55,7 @@ func GroupedTools() []ToolGroup {
 		{Name: "Tempo (Distributed Tracing)", Icon: "🔍", Tools: toolsetToMCPTools(&traces.Toolset{})},
 		{Name: "Loki (Log Management)", Icon: "📋", Tools: toolsetToMCPTools(&logs.Toolset{})},
 		{Name: "OpenTelemetry Collector", Icon: "⚙️", Tools: toolsetToMCPTools(&otelcol.Toolset{})},
+		{Name: "Alert Management", Icon: "🛡️", Tools: toolsetToMCPTools(&alertmanagement.Toolset{})},
 	}
 }
 

--- a/pkg/metrics/toolset/toolset.go
+++ b/pkg/metrics/toolset/toolset.go
@@ -6,6 +6,7 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 	"github.com/containers/kubernetes-mcp-server/pkg/toolsets"
 
+	"github.com/rhobs/obs-mcp/pkg/alertmanagement"
 	"github.com/rhobs/obs-mcp/pkg/logs"
 	"github.com/rhobs/obs-mcp/pkg/metrics/config"
 	"github.com/rhobs/obs-mcp/pkg/metrics/toolset_tools"
@@ -65,4 +66,5 @@ func init() {
 	toolsets.Register(&tempo.Toolset{})
 	toolsets.Register(&logs.Toolset{})
 	toolsets.Register(&otelcol.Toolset{})
+	toolsets.Register(&alertmanagement.Toolset{})
 }


### PR DESCRIPTION
## Summary

- Add `pkg/alertmanagement/` package with `Toolset`, `Config`, and `ServerPrompt` following the otelcol pattern
- Wire into standalone binary (`--alert-mgmt-api-url` flag, `ALERT_MGMT_API_URL` env var), kubernetes-mcp-server embed path, and doc generation
- No tool implementations yet — scaffolding only to validate naming, config structure, and registration

## What This PR Does NOT Include

- No MCP tool implementations (create, delete, list, update)
- No handler code or schema definitions
- No monitoring-plugin management API integration
- No tests beyond compilation verification

This is intentionally minimal to get early feedback on the toolset design before the monitoring-plugin management API lands.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./pkg/mcp/... ./cmd/obs-mcp/... ./pkg/toolset/...` passes
- [ ] Reviewers validate: toolset naming, config structure, registration pattern

Ref: CNV-93479, [OBSDA-1445](https://redhat.atlassian.net/browse/OBSDA-1445)

Signed-off-by: Shirly Radco <sradco@redhat.com>
Co-authored-by: AI Assistant <noreply@cursor.com>