### PR TITLE
fix: do not fall back to kubeconfig token in header auth mode

### DIFF
--- a/cmd/obs-mcp/main.go
+++ b/cmd/obs-mcp/main.go
@@ -194,7 +194,8 @@ func main() { //nolint:gocyclo // main wires up flags, config, and run group
 			LokiURL:  lokiResolvedURL,
 			UseRoute: *lokiUseRoute,
 		},
-		Registry: reg,
+		KubernetesClientConfig: k8s.GetClientCmdConfig(),
+		Registry:        reg,
 	}
 
 	// Create MCP server

--- a/cmd/obs-mcp/main.go
+++ b/cmd/obs-mcp/main.go
@@ -195,7 +195,7 @@ func main() { //nolint:gocyclo // main wires up flags, config, and run group
 			UseRoute: *lokiUseRoute,
 		},
 		KubernetesClientConfig: k8s.GetClientCmdConfig(),
-		Registry:        reg,
+		Registry:               reg,
 	}
 
 	// Create MCP server

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -15,9 +15,10 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	prom "github.com/prometheus/client_golang/prometheus"
 
+	"k8s.io/client-go/tools/clientcmd"
+
 	"github.com/rhobs/obs-mcp/pkg/auth"
 	"github.com/rhobs/obs-mcp/pkg/instrumentation"
-	"github.com/rhobs/obs-mcp/pkg/k8s"
 	"github.com/rhobs/obs-mcp/pkg/logs"
 	tools "github.com/rhobs/obs-mcp/pkg/metrics"
 	"github.com/rhobs/obs-mcp/pkg/metrics/prometheus"
@@ -48,6 +49,7 @@ type ObsMCPOptions struct {
 	Traces                 *traces.Config
 	Otelcol                *otelcol.Config
 	Logs                   *logs.Config
+	KubernetesClientConfig clientcmd.ClientConfig
 	Registry               prom.Registerer
 	clientMetrics          *instrumentation.ClientMetrics
 	toolMetrics            *instrumentation.ToolMetrics
@@ -115,8 +117,7 @@ func needsKubernetes(toolsets []Toolset) bool {
 func SetupTools(mcpServer *mcp.Server, opts ObsMCPOptions) error {
 	var mgr *kubernetes.Manager
 	if needsKubernetes(opts.Toolsets) {
-		clientCmdConfig := k8s.GetClientCmdConfig()
-		restConfig, err := clientCmdConfig.ClientConfig()
+		restConfig, err := opts.KubernetesClientConfig.ClientConfig()
 		if err != nil {
 			return err
 		}
@@ -124,7 +125,7 @@ func SetupTools(mcpServer *mcp.Server, opts ObsMCPOptions) error {
 		cfg := config.BaseDefault()
 		// In header auth mode, require the caller's OAuth token instead of falling back to the kubeconfig token.
 		cfg.RequireOAuth = opts.AuthMode == auth.AuthModeHeader
-		mgr, mgrErr = kubernetes.NewManager(context.Background(), cfg, restConfig, clientCmdConfig)
+		mgr, mgrErr = kubernetes.NewManager(context.Background(), cfg, restConfig, opts.KubernetesClientConfig)
 		if mgrErr != nil {
 			return mgrErr
 		}

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -121,7 +121,10 @@ func SetupTools(mcpServer *mcp.Server, opts ObsMCPOptions) error {
 			return err
 		}
 		var mgrErr error
-		mgr, mgrErr = kubernetes.NewManager(context.Background(), config.BaseDefault(), restConfig, clientCmdConfig)
+		cfg := config.BaseDefault()
+		// In header auth mode, require the caller's OAuth token instead of falling back to the kubeconfig token.
+		cfg.RequireOAuth = opts.AuthMode == auth.AuthModeHeader
+		mgr, mgrErr = kubernetes.NewManager(context.Background(), cfg, restConfig, clientCmdConfig)
 		if mgrErr != nil {
 			return mgrErr
 		}

--- a/pkg/mcp/server_test.go
+++ b/pkg/mcp/server_test.go
@@ -1,11 +1,19 @@
 package mcp
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/rhobs/obs-mcp/pkg/auth"
+	"github.com/rhobs/obs-mcp/pkg/otelcol"
 )
 
 func TestAuthMiddleware(t *testing.T) {
@@ -63,6 +71,62 @@ func TestAuthMiddleware(t *testing.T) {
 			}
 			if gotCtxValue != tt.wantCtxValue {
 				t.Errorf("context value = %q, want %q", gotCtxValue, tt.wantCtxValue)
+			}
+		})
+	}
+}
+
+func TestHeaderAuthRejectsUnauthenticatedToolCall(t *testing.T) {
+	kubeClientConfig := clientcmd.NewDefaultClientConfig(clientcmdapi.Config{
+		Clusters:       map[string]*clientcmdapi.Cluster{"test": {Server: "https://localhost", InsecureSkipTLSVerify: true}},
+		AuthInfos:      map[string]*clientcmdapi.AuthInfo{"test": {Token: "kubeconfig-token"}},
+		Contexts:       map[string]*clientcmdapi.Context{"test": {Cluster: "test", AuthInfo: "test"}},
+		CurrentContext: "test",
+	}, &clientcmd.ConfigOverrides{})
+
+	tests := []struct {
+		name      string
+		authMode  auth.AuthMode
+		expectErr string
+	}{
+		{
+			name:      "header mode rejects unauthenticated call",
+			authMode:  auth.AuthModeHeader,
+			expectErr: `calling "tools/call": oauth token required`,
+		},
+		{
+			name:     "kubeconfig mode allows unauthenticated call",
+			authMode: auth.AuthModeKubeConfig,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mcpServer, err := NewMCPServer(ObsMCPOptions{
+				Toolsets:               []Toolset{ToolsetOtelcol},
+				AuthMode:               tt.authMode,
+				Otelcol:                otelcol.NewDefaultConfig(),
+				KubernetesClientConfig: kubeClientConfig,
+			})
+			require.NoError(t, err)
+
+			clientTransport, serverTransport := mcpsdk.NewInMemoryTransports()
+			_, err = mcpServer.Connect(context.Background(), serverTransport, nil)
+			require.NoError(t, err)
+
+			client := mcpsdk.NewClient(&mcpsdk.Implementation{Name: "test-client", Version: "0.0.1"}, nil)
+			session, err := client.Connect(context.Background(), clientTransport, nil)
+			require.NoError(t, err)
+			defer session.Close()
+
+			_, err = session.CallTool(context.Background(), &mcpsdk.CallToolParams{
+				Name: "otelcol_list_components",
+			})
+
+			if tt.expectErr != "" {
+				require.EqualError(t, err, tt.expectErr)
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/pkg/mcp/tools_gosdk.go
+++ b/pkg/mcp/tools_gosdk.go
@@ -75,7 +75,9 @@ func ServerToolToGoSdkTool(mgr *kubernetes.Manager, cfg api.BaseConfig, tool api
 			return nil, fmt.Errorf("%v for tool %s", err, tool.Tool.Name)
 		}
 
-		// get the correct derived Kubernetes client for the target specified in the request
+		// Create a Kubernetes client with the bearer token of the incoming request (must be set in the context).
+		// If the context doesn't have an Authorization token set, fall back to the token in the kubeconfig,
+		// unless require_oauth is set.
 		k, err := mgr.Derived(ctx)
 		if err != nil {
 			return nil, err

--- a/tests/e2e/framework.go
+++ b/tests/e2e/framework.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"time"
 
+	authv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -21,23 +22,25 @@ import (
 )
 
 const (
-	defaultNamespace        = "obs-mcp"
-	defaultServiceName      = "obs-mcp"
-	defaultServicePort      = 9100
-	defaultLocalPort        = 9100
-	defaultPodLabelSelector = "app.kubernetes.io/name=obs-mcp"
-	defaultTimeout          = 30 * time.Second
+	defaultNamespace          = "obs-mcp"
+	defaultServiceName        = "obs-mcp"
+	defaultServiceAccountName = "obs-mcp"
+	defaultServicePort        = 9100
+	defaultLocalPort          = 9100
+	defaultPodLabelSelector   = "app.kubernetes.io/name=obs-mcp"
+	defaultTimeout            = 30 * time.Second
 )
 
 // TestConfig holds configuration and runtime state for e2e tests
 type TestConfig struct {
 	// Configuration
-	Namespace        string
-	ServiceName      string
-	ServicePort      int
-	LocalPort        int
-	PodLabelSelector string
-	Timeout          time.Duration
+	Namespace          string
+	ServiceName        string
+	ServiceAccountName string
+	ServicePort        int
+	LocalPort          int
+	PodLabelSelector   string
+	Timeout            time.Duration
 
 	// Runtime state
 	MCPURL          string
@@ -53,12 +56,13 @@ func NewTestConfig() *TestConfig {
 		namespace = defaultNamespace
 	}
 	config := &TestConfig{
-		Namespace:        namespace,
-		ServiceName:      defaultServiceName,
-		ServicePort:      defaultServicePort,
-		LocalPort:        defaultLocalPort,
-		PodLabelSelector: defaultPodLabelSelector,
-		Timeout:          defaultTimeout,
+		Namespace:          namespace,
+		ServiceName:        defaultServiceName,
+		ServiceAccountName: defaultServiceAccountName,
+		ServicePort:        defaultServicePort,
+		LocalPort:          defaultLocalPort,
+		PodLabelSelector:   defaultPodLabelSelector,
+		Timeout:            defaultTimeout,
 	}
 	fmt.Printf("Test config: namespace=%s, service=%s, port=%d, timeout=%v\n",
 		config.Namespace, config.ServiceName, config.ServicePort, config.Timeout)
@@ -222,6 +226,31 @@ func findRunningPod(pods []corev1.Pod) string {
 		}
 	}
 	return ""
+}
+
+// createServiceAccountToken requests a bearer token for the given service account via the TokenRequest API.
+func createServiceAccountToken(namespace, serviceAccountName string) (string, error) {
+	config, err := getKubeConfig()
+	if err != nil {
+		return "", fmt.Errorf("failed to get kube config: %w", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return "", fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	tokenReq, err := clientset.CoreV1().ServiceAccounts(namespace).CreateToken(
+		context.Background(),
+		serviceAccountName,
+		&authv1.TokenRequest{},
+		metav1.CreateOptions{},
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to request token via TokenRequest API: %w", err)
+	}
+
+	return tokenReq.Status.Token, nil
 }
 
 // waitForReady polls the target URL until it returns HTTP 200, timeout occurs, or context is cancelled

--- a/tests/e2e/mcp_client.go
+++ b/tests/e2e/mcp_client.go
@@ -39,15 +39,21 @@ type MCPError struct {
 
 // MCPClient provides methods for interacting with the MCP server
 type MCPClient struct {
-	baseURL string
-	client  *http.Client
+	baseURL    string
+	client     *http.Client
+	authHeader string
 }
 
-// NewMCPClient creates a new MCP client with the given base URL
-func NewMCPClient(baseURL string) *MCPClient {
+// NewMCPClient creates a new MCP client with the given base URL and bearer token.
+func NewMCPClient(baseURL string, bearerToken string) *MCPClient {
+	var authHeader string
+	if bearerToken != "" {
+		authHeader = "Bearer " + bearerToken
+	}
 	return &MCPClient{
-		baseURL: baseURL,
-		client:  &http.Client{Timeout: defaultTimeout},
+		baseURL:    baseURL,
+		client:     &http.Client{Timeout: defaultTimeout},
+		authHeader: authHeader,
 	}
 }
 
@@ -78,6 +84,9 @@ func (c *MCPClient) SendRequest(t *testing.T, req MCPRequest) (*MCPResponse, err
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Accept", "application/json, text/event-stream")
+	if c.authHeader != "" {
+		httpReq.Header.Set("Authorization", c.authHeader)
+	}
 
 	resp, err := c.client.Do(httpReq)
 	if err != nil {
@@ -150,6 +159,9 @@ func (c *MCPClient) callToolRaw(id int, toolName string, args map[string]any) (m
 	}
 	httpReq.Header.Set("Content-Type", "application/json")
 	httpReq.Header.Set("Accept", "application/json, text/event-stream")
+	if c.authHeader != "" {
+		httpReq.Header.Set("Authorization", c.authHeader)
+	}
 
 	resp, err := c.client.Do(httpReq)
 	if err != nil {

--- a/tests/e2e/openshift_e2e_test.go
+++ b/tests/e2e/openshift_e2e_test.go
@@ -185,5 +185,5 @@ func TestOtelcolToolset(t *testing.T) {
 	if mcpURL == "" {
 		t.Skip("OBS_MCP_URL not set; skipping (set OBS_MCP_URL to run against a deployed or local obs-mcp)")
 	}
-	runOtelcolToolsetTests(t, NewMCPClient(mcpURL))
+	runOtelcolToolsetTests(t, NewMCPClient(mcpURL, ""))
 }

--- a/tests/e2e/setup_test.go
+++ b/tests/e2e/setup_test.go
@@ -38,7 +38,13 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	mcpClient = NewMCPClient(testConfig.MCPURL)
+	token, err := createServiceAccountToken(testConfig.Namespace, testConfig.ServiceAccountName)
+	if err != nil {
+		fmt.Printf("Failed to get bearer token: %v\n", err)
+		os.Exit(1)
+	}
+
+	mcpClient = NewMCPClient(testConfig.MCPURL, token)
 	setupThanosDetection()
 
 	code := m.Run()

--- a/tests/e2e/setup_test.go
+++ b/tests/e2e/setup_test.go
@@ -5,6 +5,7 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
@@ -38,10 +39,11 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
+	// Token creation fails in OpenShift Prow e2e tests due to limited permissions of the serviceaccount running the tests,
+	// however there we use kubeconfig auth mode on OpenShift and therefore do not need to send an auth header.
 	token, err := createServiceAccountToken(testConfig.Namespace, testConfig.ServiceAccountName)
 	if err != nil {
-		fmt.Printf("Failed to get bearer token: %v\n", err)
-		os.Exit(1)
+		slog.Warn("Failed to create a service account token, continuing without authenticating MCP tool calls", "err", err)
 	}
 
 	mcpClient = NewMCPClient(testConfig.MCPURL, token)


### PR DESCRIPTION
mgr.Derived(ctx) of kubernetes-mcp-client falls back to the kubeconfig auth token if no OAuth token is present in the context.

In header auth mode, this should not happen, therefore we must set require_oauth to true to disable this fallback and enforce a bearer token in the header.