### PR TITLE
chore: move metric tools config from ObsMCPOptions to metrics.Config

### DIFF
--- a/cmd/obs-mcp/main.go
+++ b/cmd/obs-mcp/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/rhobs/obs-mcp/pkg/k8s"
 	"github.com/rhobs/obs-mcp/pkg/logs"
 	mcpserver "github.com/rhobs/obs-mcp/pkg/mcp"
+	"github.com/rhobs/obs-mcp/pkg/metrics"
 	"github.com/rhobs/obs-mcp/pkg/metrics/prometheus"
 	"github.com/rhobs/obs-mcp/pkg/otelcol"
 	"github.com/rhobs/obs-mcp/pkg/traces"
@@ -37,11 +38,11 @@ const (
 	defaultAlertmanagerURL = "http://localhost:9093"
 )
 
-func main() { //nolint:gocyclo // main wires up flags, config, and run group
+func main() {
 	var showVersion = flag.Bool("version", false, "Print version and exit")
 	var listen = flag.String("listen", "", "Listen address for HTTP mode (e.g., :9100, 127.0.0.1:8080)")
 	var listenInternal = flag.String("listen-internal", "", "Listen address for internal health server (metrics, pprof, health e.g., :8081, 127.0.0.1:8081). Off by default.")
-	var toolsets = flag.String("toolsets", string(mcpserver.ToolsetMetrics), fmt.Sprintf("Comma-separated list of enabled toolsets: %s", strings.Join(mcpserver.AllToolsets, ", ")))
+	var toolsets = flag.String("toolsets", metrics.ToolsetName, fmt.Sprintf("Comma-separated list of enabled toolsets: %s", strings.Join(mcpserver.AllToolsets, ", ")))
 	var authMode = flag.String("auth-mode", "", "Authentication mode: kubeconfig or header")
 	var insecure = flag.Bool("insecure", false, "Skip TLS certificate verification")
 	var logLevel = flag.String("log-level", "info", "Log level: debug, info, warn, error")
@@ -104,7 +105,7 @@ func main() { //nolint:gocyclo // main wires up flags, config, and run group
 
 	metricsBackendURL := ""
 	metricsURLSource := ""
-	if slices.Contains(parsedToolsets, mcpserver.ToolsetMetrics) {
+	if slices.Contains(parsedToolsets, metrics.ToolsetName) {
 		metricsBackendURL, metricsURLSource, err = determineMetricsBackendURL(parsedAuthMode, parsedMetricsBackend)
 		if err != nil {
 			log.Fatalf("%v", err)
@@ -113,7 +114,7 @@ func main() { //nolint:gocyclo // main wires up flags, config, and run group
 
 	alertmanagerURL := ""
 	alertmanagerURLSource := ""
-	if slices.Contains(parsedToolsets, mcpserver.ToolsetMetrics) {
+	if slices.Contains(parsedToolsets, metrics.ToolsetName) {
 		alertmanagerURL, alertmanagerURLSource, err = determineAlertmanagerURL(parsedAuthMode)
 		if err != nil {
 			log.Fatalf("%v", err)
@@ -130,40 +131,6 @@ func main() { //nolint:gocyclo // main wires up flags, config, and run group
 		}
 	}
 
-	// Parse guardrails configuration
-	parsedGuardrails, err := prometheus.ParseGuardrails(*guardrails)
-	if err != nil {
-		log.Fatalf("Invalid guardrails configuration: %v", err)
-	}
-
-	// Reject deprecated use of 0 to disable the metric cardinality guardrail.
-	if isFlagExplicitlySet("guardrails.max-metric-cardinality") && *maxMetricCardinality == 0 {
-		log.Fatalf("--guardrails.max-metric-cardinality=0 is no longer supported to disable the guardrail; "+
-			"use '!%s' in --guardrails instead", prometheus.GuardrailMaxMetricCardinality)
-	}
-
-	// Reject cardinality flags that have no effect given the active guardrails.
-	if isFlagExplicitlySet("guardrails.max-metric-cardinality") &&
-		(parsedGuardrails == nil || !parsedGuardrails.ForceMaxMetricCardinality) {
-		log.Fatalf("--guardrails.max-metric-cardinality has no effect: add %q to --guardrails to enable the metric cardinality guardrail",
-			prometheus.GuardrailMaxMetricCardinality)
-	}
-	if isFlagExplicitlySet("guardrails.max-label-cardinality") &&
-		(parsedGuardrails == nil || !parsedGuardrails.DisallowBlanketRegex) {
-		log.Fatalf("--guardrails.max-label-cardinality has no effect: add %q to --guardrails to enable the blanket-regex guardrail",
-			prometheus.GuardrailDisallowBlanketRegex)
-	}
-
-	// Set max metric cardinality and max label cardinality if the corresponding guardrails are enabled.
-	if parsedGuardrails != nil {
-		if parsedGuardrails.ForceMaxMetricCardinality {
-			parsedGuardrails.MaxMetricCardinality = *maxMetricCardinality
-		}
-		if parsedGuardrails.DisallowBlanketRegex {
-			parsedGuardrails.MaxLabelCardinality = *maxLabelCardinality
-		}
-	}
-
 	// Determine Tempo URL only when traces toolset is enabled.
 	tempoResolvedURL := ""
 	tempoURLSource := ""
@@ -173,13 +140,15 @@ func main() { //nolint:gocyclo // main wires up flags, config, and run group
 
 	// Create MCP options
 	opts := mcpserver.ObsMCPOptions{
-		Toolsets:               parsedToolsets,
-		AuthMode:               parsedAuthMode,
-		MetricsBackendURL:      metricsBackendURL,
-		AlertmanagerURL:        alertmanagerURL,
-		Insecure:               *insecure,
-		Guardrails:             parsedGuardrails,
-		FullRangeQueryResponse: *fullRangeQueryResponse,
+		Toolsets: parsedToolsets,
+		Metrics: &metrics.Config{
+			AuthMode:               parsedAuthMode,
+			Insecure:               *insecure,
+			PrometheusURL:          metricsBackendURL,
+			AlertmanagerURL:        alertmanagerURL,
+			Guardrails:             *guardrails,
+			RangeQueryFullResponse: *fullRangeQueryResponse,
+		},
 		Traces: &traces.Config{
 			AuthMode: parsedAuthMode,
 			Insecure: *insecure,
@@ -197,6 +166,16 @@ func main() { //nolint:gocyclo // main wires up flags, config, and run group
 		Registry:               reg,
 	}
 
+	// Only pass cardinality overrides to the config when the flags are explicitly set.
+	// flag.Uint64 always returns a non-nil pointer (pointing to the default value),
+	// but the config treats non-nil as "override", so we nil them out when unset.
+	if isFlagExplicitlySet("guardrails.max-metric-cardinality") {
+		opts.Metrics.MaxMetricCardinality = maxMetricCardinality
+	}
+	if isFlagExplicitlySet("guardrails.max-label-cardinality") {
+		opts.Metrics.MaxLabelCardinality = maxLabelCardinality
+	}
+
 	if err := validateConfigs(opts); err != nil {
 		log.Fatalf("%v", err)
 	}
@@ -211,16 +190,16 @@ func main() { //nolint:gocyclo // main wires up flags, config, and run group
 
 	slog.Info("Starting server",
 		"toolsets", opts.Toolsets,
-		"auth_mode", opts.AuthMode,
-		"metrics_backend_url", opts.MetricsBackendURL,
+		"auth_mode", parsedAuthMode,
+		"metrics_backend_url", opts.Metrics.PrometheusURL,
 		"metrics_backend_url_source", metricsURLSource,
-		"alertmanager_url", opts.AlertmanagerURL,
+		"alertmanager_url", opts.Metrics.AlertmanagerURL,
 		"alertmanager_url_source", alertmanagerURLSource,
 		"loki_url", opts.Logs.LokiURL,
 		"loki_url_source", lokiURLSource,
 		"tempo_url", tempoResolvedURL,
 		"tempo_url_source", tempoURLSource,
-		"guardrails", opts.Guardrails,
+		"guardrails", opts.Metrics.Guardrails,
 	)
 
 	var g run.Group
@@ -301,6 +280,11 @@ func interrupt(cancel <-chan struct{}) error {
 }
 
 func validateConfigs(opts mcpserver.ObsMCPOptions) error {
+	if slices.Contains(opts.Toolsets, metrics.ToolsetName) {
+		if err := opts.Metrics.Validate(); err != nil {
+			return fmt.Errorf("invalid metrics config: %w", err)
+		}
+	}
 	if slices.Contains(opts.Toolsets, logs.ToolsetName) {
 		if err := opts.Logs.Validate(); err != nil {
 			return fmt.Errorf("invalid logs config: %w", err)

--- a/pkg/mcp/auth.go
+++ b/pkg/mcp/auth.go
@@ -34,7 +34,7 @@ func getPromClient(ctx context.Context, opts ObsMCPOptions) (prometheus.Loader, 
 
 	// Normal production path
 
-	apiConfig, err := createAPIConfig(ctx, opts, opts.MetricsBackendURL)
+	apiConfig, err := createAPIConfig(ctx, opts, opts.Metrics.PrometheusURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create API config: %w", err)
 	}
@@ -49,7 +49,11 @@ func getPromClient(ctx context.Context, opts ObsMCPOptions) (prometheus.Loader, 
 		return nil, fmt.Errorf("failed to create Prometheus client: %w", err)
 	}
 
-	promClient.WithGuardrails(opts.Guardrails)
+	guardrails, err := opts.Metrics.GetGuardrails()
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse guardrails: %w", err)
+	}
+	promClient.WithGuardrails(guardrails)
 
 	return promClient, nil
 }
@@ -62,13 +66,10 @@ func getAlertmanagerClient(ctx context.Context, opts ObsMCPOptions) (alertmanage
 		}
 	}
 
-	apiConfig, err := createAPIConfig(ctx, opts, opts.AlertmanagerURL)
+	apiConfig, err := createAPIConfig(ctx, opts, opts.Metrics.AlertmanagerURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create API config: %w", err)
 	}
-
-	// Update the address to use AlertmanagerURL instead of MetricsBackendURL
-	apiConfig.Address = opts.AlertmanagerURL
 
 	// Instrument the RoundTripper for Alertmanager client
 	if opts.clientMetrics != nil && apiConfig.RoundTripper != nil {
@@ -90,7 +91,7 @@ func createAPIConfig(ctx context.Context, opts ObsMCPOptions, url string) (proma
 	}
 
 	tls := strings.HasPrefix(url, "https://")
-	rt, err := auth.BuildRoundTripper(ctx, restConfig, opts.AuthMode, tls, opts.Insecure)
+	rt, err := auth.BuildRoundTripper(ctx, restConfig, opts.Metrics.GetAuthMode(), tls, opts.Metrics.Insecure)
 	if err != nil {
 		return promapi.Config{}, fmt.Errorf("failed to create round tripper: %w", err)
 	}

--- a/pkg/mcp/handlers.go
+++ b/pkg/mcp/handlers.go
@@ -73,7 +73,7 @@ func ExecuteRangeQueryHandler(opts ObsMCPOptions) mcp.ToolHandlerFor[tools.Range
 			return nil, tools.RangeQueryOutput{}, fmt.Errorf("failed to create Prometheus client: %w", err)
 		}
 
-		result := tools.ExecuteRangeQueryHandler(ctx, promClient, input, opts.FullRangeQueryResponse)
+		result := tools.ExecuteRangeQueryHandler(ctx, promClient, input, opts.Metrics.RangeQueryFullResponse)
 		output, err := resultutil.Unwrap[tools.RangeQueryOutput](result)
 		if err != nil {
 			return nil, tools.RangeQueryOutput{}, err

--- a/pkg/mcp/handlers_test.go
+++ b/pkg/mcp/handlers_test.go
@@ -145,7 +145,7 @@ func TestExecuteRangeQueryHandler_ExplicitTimeRange_RFC3339(t *testing.T) {
 	}
 
 	ctx := withMockClient(context.Background(), mockClient)
-	handler := ExecuteRangeQueryHandler(ObsMCPOptions{})
+	handler := ExecuteRangeQueryHandler(ObsMCPOptions{Metrics: &tools.Config{}})
 
 	paramsMap := map[string]any{
 		"query": "up{job=\"api\"}",
@@ -169,7 +169,7 @@ func TestExecuteRangeQueryHandler_StepParsing_ValidSteps(t *testing.T) {
 	}
 
 	ctx := withMockClient(t.Context(), mockClient)
-	handler := ExecuteRangeQueryHandler(ObsMCPOptions{})
+	handler := ExecuteRangeQueryHandler(ObsMCPOptions{Metrics: &tools.Config{}})
 
 	paramsMap := map[string]any{
 		"query": "up{job=\"api\"}",
@@ -284,7 +284,7 @@ func TestExecuteRangeQueryHandler_RequiredParameters(t *testing.T) {
 			mockClient := &MockedLoader{}
 
 			ctx := withMockClient(t.Context(), mockClient)
-			handler := ExecuteRangeQueryHandler(ObsMCPOptions{})
+			handler := ExecuteRangeQueryHandler(ObsMCPOptions{Metrics: &tools.Config{}})
 			req := newMockRequest(tt.params)
 
 			input := tools.BuildRangeQueryInput(tt.params)
@@ -321,7 +321,7 @@ func TestExecuteRangeQueryHandler_DurationMode_DefaultOneHour(t *testing.T) {
 	}
 
 	ctx := withMockClient(t.Context(), mockClient)
-	handler := ExecuteRangeQueryHandler(ObsMCPOptions{})
+	handler := ExecuteRangeQueryHandler(ObsMCPOptions{Metrics: &tools.Config{}})
 	paramsMap := map[string]any{
 		"query": "up{job=\"api\"}",
 		"step":  "1m",
@@ -353,7 +353,7 @@ func TestExecuteRangeQueryHandler_DurationMode_CustomDuration(t *testing.T) {
 	}
 
 	ctx := withMockClient(t.Context(), mockClient)
-	handler := ExecuteRangeQueryHandler(ObsMCPOptions{})
+	handler := ExecuteRangeQueryHandler(ObsMCPOptions{Metrics: &tools.Config{}})
 	paramsMap := map[string]any{
 		"query":    "rate(http_requests_total{job=\"api\"}[5m])",
 		"step":     "30s",
@@ -379,7 +379,7 @@ func TestExecuteRangeQueryHandler_DurationMode_NOWKeyword(t *testing.T) {
 	}
 
 	ctx := withMockClient(t.Context(), mockClient)
-	handler := ExecuteRangeQueryHandler(ObsMCPOptions{})
+	handler := ExecuteRangeQueryHandler(ObsMCPOptions{Metrics: &tools.Config{}})
 	paramsMap := map[string]any{
 		"query":    "up{job=\"api\"}",
 		"step":     "1m",
@@ -415,7 +415,7 @@ func TestExecuteRangeQueryHandler_NOWKeyword_CaseInsensitive(t *testing.T) {
 			}
 
 			ctx := withMockClient(context.Background(), mockClient)
-			handler := ExecuteRangeQueryHandler(ObsMCPOptions{})
+			handler := ExecuteRangeQueryHandler(ObsMCPOptions{Metrics: &tools.Config{}})
 			paramsMap := map[string]any{
 				"query": "up{job=\"api\"}",
 				"step":  "1m",
@@ -449,7 +449,7 @@ func TestExecuteInstantQueryHandler_NOWKeyword_CaseInsensitive(t *testing.T) {
 			}
 
 			ctx := withMockClient(context.Background(), mockClient)
-			handler := ExecuteInstantQueryHandler(ObsMCPOptions{})
+			handler := ExecuteInstantQueryHandler(ObsMCPOptions{Metrics: &tools.Config{}})
 			paramsMap := map[string]any{
 				"query": "up{job=\"api\"}",
 				"time":  nowStr,
@@ -546,7 +546,7 @@ func TestExecuteRangeQueryHandler_RelativeTime(t *testing.T) {
 			}
 
 			ctx := withMockClient(context.Background(), mockClient)
-			handler := ExecuteRangeQueryHandler(ObsMCPOptions{})
+			handler := ExecuteRangeQueryHandler(ObsMCPOptions{Metrics: &tools.Config{}})
 			paramsMap := map[string]any{
 				"query": "up{job=\"api\"}",
 				"step":  "1m",
@@ -577,7 +577,7 @@ func TestShowTimeseriesHandler(t *testing.T) {
 	}
 
 	ctx := withMockClient(context.Background(), mockClient)
-	handler := ShowTimeseriesHandler(ObsMCPOptions{})
+	handler := ShowTimeseriesHandler(ObsMCPOptions{Metrics: &tools.Config{}})
 	req := newMockRequest(map[string]any{
 		"query": "up{job=\"api\"}",
 		"step":  "1m",
@@ -664,7 +664,7 @@ func TestExecuteInstantQueryHandler_RelativeTime(t *testing.T) {
 			}
 
 			ctx := withMockClient(context.Background(), mockClient)
-			handler := ExecuteInstantQueryHandler(ObsMCPOptions{})
+			handler := ExecuteInstantQueryHandler(ObsMCPOptions{Metrics: &tools.Config{}})
 			paramsMap := map[string]any{
 				"query": "up{job=\"api\"}",
 				"time":  tt.time,
@@ -719,7 +719,7 @@ func TestGetAlertsHandler_AllAlerts(t *testing.T) {
 	}
 
 	ctx := withMockAlertmanagerClient(context.Background(), mockClient)
-	handler := GetAlertsHandler(ObsMCPOptions{})
+	handler := GetAlertsHandler(ObsMCPOptions{Metrics: &tools.Config{}})
 	req := newMockRequest(map[string]any{})
 
 	input := tools.BuildAlertsInput(map[string]any{})
@@ -761,7 +761,7 @@ func TestGetAlertsHandler_WithActiveFilter(t *testing.T) {
 	}
 
 	ctx := withMockAlertmanagerClient(context.Background(), mockClient)
-	handler := GetAlertsHandler(ObsMCPOptions{})
+	handler := GetAlertsHandler(ObsMCPOptions{Metrics: &tools.Config{}})
 	paramsMap := map[string]any{
 		"active": active,
 	}
@@ -805,7 +805,7 @@ func TestGetAlertsHandler_WithFilter(t *testing.T) {
 	}
 
 	ctx := withMockAlertmanagerClient(context.Background(), mockClient)
-	handler := GetAlertsHandler(ObsMCPOptions{})
+	handler := GetAlertsHandler(ObsMCPOptions{Metrics: &tools.Config{}})
 	paramsMap := map[string]any{
 		"filter": "alertname=HighCPU",
 	}
@@ -849,7 +849,7 @@ func TestGetAlertsHandler_WithReceiver(t *testing.T) {
 	}
 
 	ctx := withMockAlertmanagerClient(context.Background(), mockClient)
-	handler := GetAlertsHandler(ObsMCPOptions{})
+	handler := GetAlertsHandler(ObsMCPOptions{Metrics: &tools.Config{}})
 	paramsMap := map[string]any{
 		"receiver": "team-notifications",
 	}
@@ -898,7 +898,7 @@ func TestGetSilencesHandler_AllSilences(t *testing.T) {
 	}
 
 	ctx := withMockAlertmanagerClient(context.Background(), mockClient)
-	handler := GetSilencesHandler(ObsMCPOptions{})
+	handler := GetSilencesHandler(ObsMCPOptions{Metrics: &tools.Config{}})
 	req := newMockRequest(map[string]any{})
 
 	input := tools.BuildSilencesInput(map[string]any{})
@@ -945,7 +945,7 @@ func TestGetSilencesHandler_WithFilter(t *testing.T) {
 	}
 
 	ctx := withMockAlertmanagerClient(context.Background(), mockClient)
-	handler := GetSilencesHandler(ObsMCPOptions{})
+	handler := GetSilencesHandler(ObsMCPOptions{Metrics: &tools.Config{}})
 	paramsMap := map[string]any{
 		"filter": "alertname=HighCPU",
 	}
@@ -966,7 +966,7 @@ func TestGetSilencesHandler_EmptyResult(t *testing.T) {
 	}
 
 	ctx := withMockAlertmanagerClient(context.Background(), mockClient)
-	handler := GetSilencesHandler(ObsMCPOptions{})
+	handler := GetSilencesHandler(ObsMCPOptions{Metrics: &tools.Config{}})
 	req := newMockRequest(map[string]any{})
 
 	input := tools.BuildSilencesInput(map[string]any{})
@@ -984,7 +984,7 @@ func TestGetAlertsHandler_ClientError(t *testing.T) {
 	}
 
 	ctx := withMockAlertmanagerClient(context.Background(), mockClient)
-	handler := GetAlertsHandler(ObsMCPOptions{})
+	handler := GetAlertsHandler(ObsMCPOptions{Metrics: &tools.Config{}})
 	req := newMockRequest(map[string]any{})
 
 	input := tools.BuildAlertsInput(map[string]any{})
@@ -1036,7 +1036,7 @@ func TestGetAlertsHandler_WithMultipleFilters(t *testing.T) {
 	}
 
 	ctx := withMockAlertmanagerClient(context.Background(), mockClient)
-	handler := GetAlertsHandler(ObsMCPOptions{})
+	handler := GetAlertsHandler(ObsMCPOptions{Metrics: &tools.Config{}})
 	paramsMap := map[string]any{
 		"filter": "alertname=HighCPU, severity=critical",
 	}
@@ -1087,7 +1087,7 @@ func TestGetAlertsHandler_WithMultipleFiltersNoSpaces(t *testing.T) {
 	}
 
 	ctx := withMockAlertmanagerClient(context.Background(), mockClient)
-	handler := GetAlertsHandler(ObsMCPOptions{})
+	handler := GetAlertsHandler(ObsMCPOptions{Metrics: &tools.Config{}})
 	paramsMap := map[string]any{
 		"filter": "alertname=HighCPU,severity=warning,job=api",
 	}
@@ -1108,7 +1108,7 @@ func TestGetAlertsHandler_EmptyResult(t *testing.T) {
 	}
 
 	ctx := withMockAlertmanagerClient(context.Background(), mockClient)
-	handler := GetAlertsHandler(ObsMCPOptions{})
+	handler := GetAlertsHandler(ObsMCPOptions{Metrics: &tools.Config{}})
 	req := newMockRequest(map[string]any{})
 
 	input := tools.BuildAlertsInput(map[string]any{})
@@ -1126,7 +1126,7 @@ func TestGetSilencesHandler_ClientError(t *testing.T) {
 	}
 
 	ctx := withMockAlertmanagerClient(context.Background(), mockClient)
-	handler := GetSilencesHandler(ObsMCPOptions{})
+	handler := GetSilencesHandler(ObsMCPOptions{Metrics: &tools.Config{}})
 	req := newMockRequest(map[string]any{})
 
 	input := tools.BuildSilencesInput(map[string]any{})

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -14,34 +14,25 @@ import (
 	"github.com/containers/kubernetes-mcp-server/pkg/kubernetes"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	prom "github.com/prometheus/client_golang/prometheus"
-
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/rhobs/obs-mcp/pkg/auth"
 	"github.com/rhobs/obs-mcp/pkg/instrumentation"
 	"github.com/rhobs/obs-mcp/pkg/logs"
-	tools "github.com/rhobs/obs-mcp/pkg/metrics"
-	"github.com/rhobs/obs-mcp/pkg/metrics/prometheus"
+	"github.com/rhobs/obs-mcp/pkg/metrics"
 	"github.com/rhobs/obs-mcp/pkg/otelcol"
 	"github.com/rhobs/obs-mcp/pkg/traces"
 )
 
-const ToolsetMetrics = "observability/metrics"
-
-var AllToolsets = []string{ToolsetMetrics, logs.ToolsetName, traces.ToolsetName, otelcol.ToolsetName}
+var AllToolsets = []string{metrics.ToolsetName, logs.ToolsetName, traces.ToolsetName, otelcol.ToolsetName}
 
 // ObsMCPOptions contains configuration options for the MCP server
 type ObsMCPOptions struct {
 	Toolsets               []string
-	AuthMode               auth.AuthMode
-	MetricsBackendURL      string
-	AlertmanagerURL        string
-	Insecure               bool
-	Guardrails             *prometheus.Guardrails
-	FullRangeQueryResponse bool
+	Metrics                *metrics.Config
+	Logs                   *logs.Config
 	Traces                 *traces.Config
 	Otelcol                *otelcol.Config
-	Logs                   *logs.Config
 	KubernetesClientConfig clientcmd.ClientConfig
 	Registry               prom.Registerer
 	clientMetrics          *instrumentation.ClientMetrics
@@ -72,8 +63,8 @@ func NewMCPServer(opts ObsMCPOptions) (*mcp.Server, error) {
 	}
 
 	var instructions []string
-	if slices.Contains(opts.Toolsets, ToolsetMetrics) {
-		instructions = append(instructions, tools.ServerPrompt)
+	if slices.Contains(opts.Toolsets, metrics.ToolsetName) {
+		instructions = append(instructions, metrics.ServerPrompt)
 	}
 	if slices.Contains(opts.Toolsets, traces.ToolsetName) {
 		instructions = append(instructions, traces.ServerPrompt)
@@ -117,32 +108,33 @@ func SetupTools(mcpServer *mcp.Server, opts ObsMCPOptions) error {
 		var mgrErr error
 		cfg := config.BaseDefault()
 		// In header auth mode, require the caller's OAuth token instead of falling back to the kubeconfig token.
-		cfg.RequireOAuth = opts.AuthMode == auth.AuthModeHeader
+		// In standalone mode, all toolset configs have the same AuthMode, because it's a single CLI flag.
+		cfg.RequireOAuth = opts.Metrics.AuthMode == auth.AuthModeHeader
 		mgr, mgrErr = kubernetes.NewManager(context.Background(), cfg, restConfig, opts.KubernetesClientConfig)
 		if mgrErr != nil {
 			return mgrErr
 		}
 	}
 
-	if slices.Contains(opts.Toolsets, ToolsetMetrics) {
-		mcp.AddTool(mcpServer, tools.ListMetrics.ToMCPTool(),
-			instrumentation.ToolHandler(tools.ListMetrics.Name, opts.toolMetrics, ListMetricsHandler(opts)))
-		mcp.AddTool(mcpServer, tools.ExecuteInstantQuery.ToMCPTool(),
-			instrumentation.ToolHandler(tools.ExecuteInstantQuery.Name, opts.toolMetrics, ExecuteInstantQueryHandler(opts)))
-		mcp.AddTool(mcpServer, tools.ExecuteRangeQuery.ToMCPTool(),
-			instrumentation.ToolHandler(tools.ExecuteRangeQuery.Name, opts.toolMetrics, ExecuteRangeQueryHandler(opts)))
-		mcp.AddTool(mcpServer, tools.ShowTimeseries.ToMCPTool(),
-			instrumentation.ToolHandler(tools.ShowTimeseries.Name, opts.toolMetrics, ShowTimeseriesHandler(opts)))
-		mcp.AddTool(mcpServer, tools.GetLabelNames.ToMCPTool(),
-			instrumentation.ToolHandler(tools.GetLabelNames.Name, opts.toolMetrics, GetLabelNamesHandler(opts)))
-		mcp.AddTool(mcpServer, tools.GetLabelValues.ToMCPTool(),
-			instrumentation.ToolHandler(tools.GetLabelValues.Name, opts.toolMetrics, GetLabelValuesHandler(opts)))
-		mcp.AddTool(mcpServer, tools.GetSeries.ToMCPTool(),
-			instrumentation.ToolHandler(tools.GetSeries.Name, opts.toolMetrics, GetSeriesHandler(opts)))
-		mcp.AddTool(mcpServer, tools.GetAlerts.ToMCPTool(),
-			instrumentation.ToolHandler(tools.GetAlerts.Name, opts.toolMetrics, GetAlertsHandler(opts)))
-		mcp.AddTool(mcpServer, tools.GetSilences.ToMCPTool(),
-			instrumentation.ToolHandler(tools.GetSilences.Name, opts.toolMetrics, GetSilencesHandler(opts)))
+	if slices.Contains(opts.Toolsets, metrics.ToolsetName) {
+		mcp.AddTool(mcpServer, metrics.ListMetrics.ToMCPTool(),
+			instrumentation.ToolHandler(metrics.ListMetrics.Name, opts.toolMetrics, ListMetricsHandler(opts)))
+		mcp.AddTool(mcpServer, metrics.ExecuteInstantQuery.ToMCPTool(),
+			instrumentation.ToolHandler(metrics.ExecuteInstantQuery.Name, opts.toolMetrics, ExecuteInstantQueryHandler(opts)))
+		mcp.AddTool(mcpServer, metrics.ExecuteRangeQuery.ToMCPTool(),
+			instrumentation.ToolHandler(metrics.ExecuteRangeQuery.Name, opts.toolMetrics, ExecuteRangeQueryHandler(opts)))
+		mcp.AddTool(mcpServer, metrics.ShowTimeseries.ToMCPTool(),
+			instrumentation.ToolHandler(metrics.ShowTimeseries.Name, opts.toolMetrics, ShowTimeseriesHandler(opts)))
+		mcp.AddTool(mcpServer, metrics.GetLabelNames.ToMCPTool(),
+			instrumentation.ToolHandler(metrics.GetLabelNames.Name, opts.toolMetrics, GetLabelNamesHandler(opts)))
+		mcp.AddTool(mcpServer, metrics.GetLabelValues.ToMCPTool(),
+			instrumentation.ToolHandler(metrics.GetLabelValues.Name, opts.toolMetrics, GetLabelValuesHandler(opts)))
+		mcp.AddTool(mcpServer, metrics.GetSeries.ToMCPTool(),
+			instrumentation.ToolHandler(metrics.GetSeries.Name, opts.toolMetrics, GetSeriesHandler(opts)))
+		mcp.AddTool(mcpServer, metrics.GetAlerts.ToMCPTool(),
+			instrumentation.ToolHandler(metrics.GetAlerts.Name, opts.toolMetrics, GetAlertsHandler(opts)))
+		mcp.AddTool(mcpServer, metrics.GetSilences.ToMCPTool(),
+			instrumentation.ToolHandler(metrics.GetSilences.Name, opts.toolMetrics, GetSilencesHandler(opts)))
 	}
 
 	if slices.Contains(opts.Toolsets, traces.ToolsetName) {

--- a/pkg/mcp/server_test.go
+++ b/pkg/mcp/server_test.go
@@ -13,6 +13,7 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/rhobs/obs-mcp/pkg/auth"
+	"github.com/rhobs/obs-mcp/pkg/metrics"
 	"github.com/rhobs/obs-mcp/pkg/otelcol"
 )
 
@@ -103,8 +104,10 @@ func TestHeaderAuthRejectsUnauthenticatedToolCall(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mcpServer, err := NewMCPServer(ObsMCPOptions{
-				Toolsets:               []string{otelcol.ToolsetName},
-				AuthMode:               tt.authMode,
+				Toolsets: []string{otelcol.ToolsetName},
+				Metrics: &metrics.Config{
+					AuthMode: tt.authMode,
+				},
 				Otelcol:                otelcol.NewDefaultConfig(),
 				KubernetesClientConfig: kubeClientConfig,
 			})

--- a/pkg/metrics/config.go
+++ b/pkg/metrics/config.go
@@ -1,4 +1,4 @@
-package config
+package metrics
 
 import (
 	"context"
@@ -12,7 +12,7 @@ import (
 	"github.com/rhobs/obs-mcp/pkg/metrics/prometheus"
 )
 
-const MetricsToolSetName = "observability/metrics"
+const ToolsetName = "observability/metrics"
 
 // Config holds obs-mcp toolset configuration
 type Config struct {
@@ -92,11 +92,13 @@ func (c *Config) GetGuardrails() (*prometheus.Guardrails, error) {
 	}
 
 	if c.MaxMetricCardinality != nil {
+		// Reject cardinality flags that have no effect given the active guardrails.
 		if guardrails == nil || !guardrails.ForceMaxMetricCardinality {
 			return nil, fmt.Errorf(
 				"max_metric_cardinality is set but the %q guardrail is not enabled",
 				prometheus.GuardrailMaxMetricCardinality)
 		}
+		// Reject deprecated use of 0 to disable the metric cardinality guardrail.
 		if *c.MaxMetricCardinality == 0 {
 			return nil, fmt.Errorf(
 				"max_metric_cardinality = 0 is not supported to disable the guardrail; use '!%s' in guardrails instead",
@@ -105,6 +107,7 @@ func (c *Config) GetGuardrails() (*prometheus.Guardrails, error) {
 		guardrails.MaxMetricCardinality = *c.MaxMetricCardinality
 	}
 	if c.MaxLabelCardinality != nil {
+		// Reject cardinality flags that have no effect given the active guardrails.
 		if guardrails == nil || !guardrails.DisallowBlanketRegex {
 			return nil, fmt.Errorf(
 				"max_label_cardinality is set but the %q guardrail is not enabled",
@@ -125,5 +128,5 @@ func obsMCPToolsetParser(_ context.Context, primitive toml.Primitive, md toml.Me
 }
 
 func init() {
-	serverconfig.RegisterToolsetConfig(MetricsToolSetName, obsMCPToolsetParser)
+	serverconfig.RegisterToolsetConfig(ToolsetName, obsMCPToolsetParser)
 }

--- a/pkg/metrics/config_test.go
+++ b/pkg/metrics/config_test.go
@@ -1,4 +1,4 @@
-package config
+package metrics
 
 import (
 	"strings"

--- a/pkg/metrics/toolset/toolset.go
+++ b/pkg/metrics/toolset/toolset.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/containers/kubernetes-mcp-server/pkg/api"
 
-	"github.com/rhobs/obs-mcp/pkg/metrics/config"
+	"github.com/rhobs/obs-mcp/pkg/metrics"
 	"github.com/rhobs/obs-mcp/pkg/metrics/toolset_tools"
 )
 
@@ -16,7 +16,7 @@ var _ api.Toolset = (*Toolset)(nil)
 
 // GetName returns the name of the toolset.
 func (t *Toolset) GetName() string {
-	return config.MetricsToolSetName
+	return metrics.ToolsetName
 }
 
 // GetDescription returns a human-readable description of the toolset.

--- a/pkg/metrics/toolset_tools/prometheus_client.go
+++ b/pkg/metrics/toolset_tools/prometheus_client.go
@@ -9,8 +9,8 @@ import (
 	promapi "github.com/prometheus/client_golang/api"
 
 	"github.com/rhobs/obs-mcp/pkg/auth"
+	"github.com/rhobs/obs-mcp/pkg/metrics"
 	"github.com/rhobs/obs-mcp/pkg/metrics/alertmanager"
-	toolsetconfig "github.com/rhobs/obs-mcp/pkg/metrics/config"
 	"github.com/rhobs/obs-mcp/pkg/metrics/prometheus"
 )
 
@@ -19,14 +19,14 @@ const (
 )
 
 // getConfig retrieves the obs-mcp toolset configuration from params.
-func getConfig(params api.ToolHandlerParams) *toolsetconfig.Config {
-	if cfg, ok := params.GetToolsetConfig(toolsetconfig.MetricsToolSetName); ok {
-		if obsCfg, ok := cfg.(*toolsetconfig.Config); ok {
+func getConfig(params api.ToolHandlerParams) *metrics.Config {
+	if cfg, ok := params.GetToolsetConfig(metrics.ToolsetName); ok {
+		if obsCfg, ok := cfg.(*metrics.Config); ok {
 			return obsCfg
 		}
 	}
 	// Return default config if not found
-	return &toolsetconfig.Config{}
+	return &metrics.Config{}
 }
 
 // getPromClient creates a Prometheus client using the toolset configuration.

--- a/pkg/metrics/toolset_tools/prometheus_client_test.go
+++ b/pkg/metrics/toolset_tools/prometheus_client_test.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/rhobs/obs-mcp/pkg/auth"
-	toolsetconfig "github.com/rhobs/obs-mcp/pkg/metrics/config"
+	"github.com/rhobs/obs-mcp/pkg/metrics"
 )
 
 type mockKubernetesClient struct {
@@ -22,7 +22,7 @@ func (m *mockKubernetesClient) RESTConfig() *rest.Config {
 
 type mockConfigProvider struct {
 	api.BaseConfig
-	config *toolsetconfig.Config
+	config *metrics.Config
 }
 
 func (m *mockConfigProvider) GetProviderConfig(string) (api.ExtendedConfig, bool) {
@@ -30,7 +30,7 @@ func (m *mockConfigProvider) GetProviderConfig(string) (api.ExtendedConfig, bool
 }
 
 func (m *mockConfigProvider) GetToolsetConfig(name string) (api.ExtendedConfig, bool) {
-	if name == toolsetconfig.MetricsToolSetName && m.config != nil {
+	if name == metrics.ToolsetName && m.config != nil {
 		return m.config, true
 	}
 	return nil, false
@@ -42,7 +42,7 @@ func (m *mockToolCallRequest) GetArguments() map[string]any {
 	return nil
 }
 
-func newTestParams(ctx context.Context, restConfig *rest.Config, cfg *toolsetconfig.Config) api.ToolHandlerParams {
+func newTestParams(ctx context.Context, restConfig *rest.Config, cfg *metrics.Config) api.ToolHandlerParams {
 	return api.ToolHandlerParams{
 		Context:          ctx,
 		KubernetesClient: &mockKubernetesClient{restConfig: restConfig},
@@ -60,7 +60,7 @@ func TestGetConfig_DefaultAuthMode(t *testing.T) {
 }
 
 func TestGetConfig_CustomAuthMode(t *testing.T) {
-	cfg := &toolsetconfig.Config{AuthMode: auth.AuthModeKubeConfig}
+	cfg := &metrics.Config{AuthMode: auth.AuthModeKubeConfig}
 	params := newTestParams(context.Background(), &rest.Config{}, cfg)
 	got := getConfig(params)
 	if got.GetAuthMode() != auth.AuthModeKubeConfig {


### PR DESCRIPTION
* utilize `metrics.Config` to store all metric toolset options
* use `metrics.Config.Validate()` to validate the guardrails, drop duplicate validation from `main.go`