### PR TITLE
breaking: remove servieaccount auth mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,18 @@ go run ./cmd/obs-mcp/ --listen 127.0.0.1:9100 --auth-mode kubeconfig --metrics-b
   ```
 
 > [!IMPORTANT]
-> **How the Loki URL is Determined (when `observability/logs` toolset is enabled):**
+> **How the Loki URL is determined (when `observability/logs` toolset is enabled):**
 >
-> 1. `--loki-url` flag (if set)
+> 1. `--loki-url` flag
 > 2. `LOKI_URL` environment variable
+> 3. `lokiNamespace`/`lokiName` tool parameters for each MCP tool call (except `loki_list_instances`)
+
+> [!IMPORTANT]
+> **How the Tempo URL is determined (when `observability/traces` toolset is enabled):**
 >
-> In `header` and `serviceaccount` modes, you can either set `--loki-url`/`LOKI_URL` **or** use LokiStack discovery (`loki_list_instances` + `lokiNamespace`/`lokiName` arguments).
+> 1. `--traces.tempo-url` flag
+> 2. `TEMPO_URL` environment variable
+> 3. `tempoNamespace`/`tempoName` tool parameters for each MCP tool call (except `tempo_list_instances`)
 
 ### 2. Port-forwarding alternative
 

--- a/cmd/obs-mcp/main.go
+++ b/cmd/obs-mcp/main.go
@@ -42,7 +42,7 @@ func main() { //nolint:gocyclo // main wires up flags, config, and run group
 	var listen = flag.String("listen", "", "Listen address for HTTP mode (e.g., :9100, 127.0.0.1:8080)")
 	var listenInternal = flag.String("listen-internal", "", "Listen address for internal health server (metrics, pprof, health e.g., :8081, 127.0.0.1:8081). Off by default.")
 	var toolsets = flag.String("toolsets", string(mcpserver.ToolsetMetrics), fmt.Sprintf("Comma-separated list of enabled toolsets: %s", strings.Join(mcpserver.AllToolsets, ", ")))
-	var authMode = flag.String("auth-mode", "", "Authentication mode: kubeconfig, serviceaccount, or header")
+	var authMode = flag.String("auth-mode", "", "Authentication mode: kubeconfig or header")
 	var insecure = flag.Bool("insecure", false, "Skip TLS certificate verification")
 	var logLevel = flag.String("log-level", "info", "Log level: debug, info, warn, error")
 	var metricsBackend = flag.String("metrics-backend", "thanos", "Metrics backend: thanos (default, with prometheus fallback) or prometheus (strict, no fallback)")
@@ -338,7 +338,7 @@ func determineMetricsBackendURL(authMode auth.AuthMode, backend k8s.MetricsBacke
 		return url, "route discovery", nil
 	}
 
-	// serviceaccount and header modes are designed for deployments where the URL
+	// header mode is designed for deployments where the URL
 	// is always known ahead of time. Falling back to localhost is never correct.
 	return "", "", fmt.Errorf(
 		"PROMETHEUS_URL must be set when using --auth-mode %s\n"+

--- a/cmd/obs-mcp/main_test.go
+++ b/cmd/obs-mcp/main_test.go
@@ -74,7 +74,7 @@ func TestParseMetricsBackend(t *testing.T) {
 }
 
 // TestDetermineMetricsBackendURL_RequiresURLForNonKubeconfigModes verifies that
-// serviceaccount and header modes return an error when PROMETHEUS_URL is not set,
+// header mode returns an error when PROMETHEUS_URL is not set,
 // rather than silently falling back to localhost.
 func TestDetermineMetricsBackendURL_RequiresURLForNonKubeconfigModes(t *testing.T) {
 	t.Setenv("PROMETHEUS_URL", "")
@@ -84,16 +84,6 @@ func TestDetermineMetricsBackendURL_RequiresURLForNonKubeconfigModes(t *testing.
 		authMode auth.AuthMode
 		backend  k8s.MetricsBackend
 	}{
-		{
-			name:     "serviceaccount mode with thanos backend",
-			authMode: auth.AuthModeServiceAccount,
-			backend:  k8s.MetricsBackendThanos,
-		},
-		{
-			name:     "serviceaccount mode with prometheus backend",
-			authMode: auth.AuthModeServiceAccount,
-			backend:  k8s.MetricsBackendPrometheus,
-		},
 		{
 			name:     "header mode with thanos backend",
 			authMode: auth.AuthModeHeader,
@@ -125,7 +115,6 @@ func TestDetermineMetricsBackendURL_EnvVarOverridesAll(t *testing.T) {
 
 	authModes := []auth.AuthMode{
 		auth.AuthModeKubeConfig,
-		auth.AuthModeServiceAccount,
 		auth.AuthModeHeader,
 	}
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -43,24 +43,15 @@ The `--auth-mode` flag controls how obs-mcp obtains bearer tokens for **Promethe
 
 | Mode             | Token Source                                                                 | Use Case                                                  |
 | ---------------- | ---------------------------------------------------------------------------- | --------------------------------------------------------- |
-| `kubeconfig`     | Bearer token from `~/.kube/config`                                           | Local development, accessing cluster via routes           |
-| `serviceaccount` | Pod's mounted token at `/var/run/secrets/kubernetes.io/serviceaccount/token` | In-cluster deployment on OpenShift/Kubernetes             |
+| `kubeconfig`     | Bearer token from `~/.kube/config` or mounted service account token          | Local development or in-cluster deployment                |
 | `header`         | Forwarded from incoming MCP request's `Authorization` header                 | Pass-through auth or when Prometheus doesn't require auth |
 
 ### `kubeconfig` mode
 
-- Extracts the bearer token from your local kubeconfig
+- Extracts the bearer token from your local kubeconfig or from the mounted service account token file
 - **Auto-discovers** Prometheus/Thanos routes in OpenShift (only mode with auto-discovery)
-- Requires token-based auth (`oc whoami -t` must return a token)
-- Best for: **Local development** when logged into a cluster
-
-### `serviceaccount` mode
-
-- Reads the service account token mounted inside the pod
-- Requires explicit `PROMETHEUS_URL` (no auto-discovery)
-- If `observability/logs` toolset is enabled, either set `LOKI_URL`/`--loki-url` or use LokiStack discovery parameters (`lokiNamespace`, `lokiName`)
-- The ServiceAccount must have RBAC permissions to query the metrics endpoint
-- Best for: **In-cluster deployment** on OpenShift with RBAC-protected Thanos/Prometheus
+- Requires token-based auth (`oc whoami -t` must return a token when running locally)
+- Best for: **Local development** when logged into a cluster, or **in-cluster deployment** on OpenShift with RBAC-protected Thanos/Prometheus
 
 ### `header` mode
 
@@ -149,9 +140,9 @@ When deploying in-cluster, you must configure:
 1. **`PROMETHEUS_URL`**: Set the environment variable to your Prometheus/Thanos endpoint
 2. **`LOKI_URL`**: Optional when using the `observability/logs` toolset (or pass `--loki-url`). If omitted, use LokiStack discovery (`loki_list_instances` + `lokiNamespace`/`lokiName` tool arguments)
 3. **`--auth-mode`**: Choose based on your backend authentication requirements:
-   - `serviceaccount` if your Prometheus requires RBAC/token auth
+   - `kubeconfig` if your Prometheus requires RBAC/token auth
    - `header` if your Prometheus doesn't require authentication
-4. **ServiceAccount RBAC**: If using `serviceaccount` mode, ensure the ServiceAccount has permissions to query your metrics/logs endpoints
+4. **ServiceAccount RBAC**: If using `kubeconfig` mode in-cluster, ensure the ServiceAccount has permissions to query your metrics/logs endpoints
 
 ### Configuring the Prometheus URL
 
@@ -159,11 +150,11 @@ The metrics backend URL is determined in the following order:
 
 1. `PROMETHEUS_URL` environment variable (if set, always used regardless of auth mode)
 2. Route discovery via the OpenShift Route API (only in `kubeconfig` mode, respects `--metrics-backend`)
-3. Fatal error — `serviceaccount` and `header` modes require `PROMETHEUS_URL` to be set explicitly
+3. Fatal error — `header` mode requires `PROMETHEUS_URL` to be set explicitly
 
 > [!NOTE]
 >
-> Auto-discovery only works in `kubeconfig` mode. For `serviceaccount` and `header` modes, the server
+> Auto-discovery only works in `kubeconfig` mode. For `header` mode, the server
 > will fail at startup if `PROMETHEUS_URL` is not set. The same applies to `ALERTMANAGER_URL` when alert tools are used.
 
 ### Guardrails and Thanos Compatibility

--- a/manifests/core/deploy/openshift/configmap.yaml
+++ b/manifests/core/deploy/openshift/configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: obs-mcp-config
   namespace: obs-mcp
 data:
-  auth-mode: "serviceaccount"
+  auth-mode: "kubeconfig"
   toolsets: "observability/metrics,observability/traces,observability/otelcol"
   # OpenShift monitoring Prometheus URL (port 9091 for OAuth proxy)
   prometheus-url: "https://prometheus-k8s.openshift-monitoring.svc:9091"

--- a/manifests/prometheus/deploy/openshift/rbac.yaml
+++ b/manifests/prometheus/deploy/openshift/rbac.yaml
@@ -3,7 +3,7 @@ kind: ClusterRole
 metadata:
   name: obs-mcp-monitoring-reader
 rules:
-  # Required for Prometheus API access with serviceaccount auth mode
+  # Required for Prometheus API access with kubeconfig auth mode
   # 'create' is needed because Prometheus uses HTTP POST for some query endpoints
   # and the Kubernetes API proxy maps POST to 'create'.
   - apiGroups: ["monitoring.coreos.com"]

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -22,8 +22,6 @@ type AuthMode string
 const (
 	// AuthModeKubeConfig reads the bearer token from the kubeconfig or from the mounted service account token file.
 	AuthModeKubeConfig AuthMode = "kubeconfig"
-	// AuthModeServiceAccount reads the bearer token from the mounted service account token file.
-	AuthModeServiceAccount AuthMode = "serviceaccount"
 	// AuthModeHeader reads the bearer token from the incoming request's authorization header.
 	// The caller must store the token in the context.
 	AuthModeHeader AuthMode = "header"
@@ -38,12 +36,10 @@ func ParseAuthMode(mode string) (AuthMode, error) {
 	switch mode {
 	case string(AuthModeKubeConfig):
 		return AuthModeKubeConfig, nil
-	case string(AuthModeServiceAccount):
-		return AuthModeServiceAccount, nil
 	case string(AuthModeHeader):
 		return AuthModeHeader, nil
 	default:
-		return "", fmt.Errorf("invalid auth mode: %s (valid options: kubeconfig, serviceaccount, header)", mode)
+		return "", fmt.Errorf("invalid auth mode: %q (valid options: %q, %q)", mode, AuthModeKubeConfig, AuthModeHeader)
 	}
 }
 

--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -11,21 +11,10 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-const (
-	serviceAccountTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
-)
-
 func readToken(ctx context.Context, restConfig *rest.Config, authMode AuthMode) (string, error) {
 	switch authMode {
 	case AuthModeKubeConfig:
 		return readTokenFromRestConfig(restConfig)
-
-	case AuthModeServiceAccount:
-		token, err := readTokenFromServiceAccountTokenFile()
-		if err != nil {
-			return "", fmt.Errorf("failed to read service account token: %w", err)
-		}
-		return string(token), nil
 
 	case AuthModeHeader:
 		// Read token from context.
@@ -60,10 +49,6 @@ func readTokenFromRestConfig(restConfig *rest.Config) (string, error) {
 	}
 
 	return "", nil
-}
-
-func readTokenFromServiceAccountTokenFile() ([]byte, error) {
-	return os.ReadFile(serviceAccountTokenPath)
 }
 
 // readTokenFromContext reads a token from the context and strips the Bearer prefix

--- a/tests/e2e/openshift_e2e_test.go
+++ b/tests/e2e/openshift_e2e_test.go
@@ -16,7 +16,7 @@ import (
 // Route discovery tests below exercise pkg/k8s directly using the kubeconfig
 // available to the test runner. They validate the auto-discovery path used when
 // obs-mcp runs locally with --auth-mode kubeconfig. The deployed server in CI
-// uses --auth-mode serviceaccount with URLs hardcoded in the configmap instead.
+// uses --auth-mode kubeconfig with URLs hardcoded in the configmap instead.
 
 // TestRouteDiscovery_ThanosQuerier verifies that the thanos-querier route in
 // openshift-monitoring can be discovered and returns a valid https:// URL.


### PR DESCRIPTION
The `kubeconfig` auth mode already reads the mounted service account token in case kubeconfig is not found.