### PR TITLE
fix: remove default loki url in kubeconfig mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ go run ./cmd/obs-mcp/ --listen 127.0.0.1:9100 --auth-mode kubeconfig --metrics-b
 >
 > 1. `--loki-url` flag (if set)
 > 2. `LOKI_URL` environment variable
-> 3. Default: `http://localhost:3100` (kubeconfig mode only)
 >
 > In `header` and `serviceaccount` modes, you can either set `--loki-url`/`LOKI_URL` **or** use LokiStack discovery (`loki_list_instances` + `lokiNamespace`/`lokiName` arguments).
 

--- a/cmd/obs-mcp/main.go
+++ b/cmd/obs-mcp/main.go
@@ -35,7 +35,6 @@ import (
 const (
 	defaultPrometheusURL   = "http://localhost:9090"
 	defaultAlertmanagerURL = "http://localhost:9093"
-	defaultLokiURL         = "http://localhost:3100"
 )
 
 func main() { //nolint:gocyclo // main wires up flags, config, and run group
@@ -125,7 +124,7 @@ func main() { //nolint:gocyclo // main wires up flags, config, and run group
 	lokiResolvedURL := ""
 	lokiURLSource := ""
 	if slices.Contains(parsedToolsets, mcpserver.ToolsetLogs) {
-		lokiResolvedURL, lokiURLSource, err = determineLokiURL(parsedAuthMode, *lokiURL, *lokiUseRoute)
+		lokiResolvedURL, lokiURLSource, err = determineLokiURL(*lokiURL)
 		if err != nil {
 			log.Fatalf("%v", err)
 		}
@@ -382,16 +381,12 @@ func determineTempoURL(flagURL string) (url, source string) {
 	return "", "unset"
 }
 
-func determineLokiURL(authMode auth.AuthMode, flagURL string, useRoute bool) (url, source string, err error) {
+func determineLokiURL(flagURL string) (url, source string, err error) {
 	if flagURL != "" {
 		return flagURL, "--loki-url flag", nil
 	}
 	if lokiURL := os.Getenv("LOKI_URL"); lokiURL != "" {
 		return lokiURL, "LOKI_URL env var", nil
-	}
-	if authMode == auth.AuthModeKubeConfig && !useRoute {
-		slog.Warn("No Loki URL configured, falling back to default", "default", defaultLokiURL)
-		return defaultLokiURL, "default", nil
 	}
 	slog.Warn("No Loki URL configured; Loki tools require lokiNamespace+lokiName discovery parameters or explicit Loki URL")
 	return "", "unset", nil

--- a/cmd/obs-mcp/main_test.go
+++ b/cmd/obs-mcp/main_test.go
@@ -148,7 +148,7 @@ func TestDetermineMetricsBackendURL_EnvVarOverridesAll(t *testing.T) {
 func TestDetermineLokiURL(t *testing.T) {
 	t.Run("explicit flag wins", func(t *testing.T) {
 		t.Setenv("LOKI_URL", "http://from-env:3100")
-		got, source, err := determineLokiURL(auth.AuthModeHeader, "http://from-flag:3100", false)
+		got, source, err := determineLokiURL("http://from-flag:3100")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -159,7 +159,7 @@ func TestDetermineLokiURL(t *testing.T) {
 
 	t.Run("env used when flag missing", func(t *testing.T) {
 		t.Setenv("LOKI_URL", "http://from-env:3100")
-		got, source, err := determineLokiURL(auth.AuthModeHeader, "", false)
+		got, source, err := determineLokiURL("")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -168,20 +168,9 @@ func TestDetermineLokiURL(t *testing.T) {
 		}
 	})
 
-	t.Run("kubeconfig falls back to default", func(t *testing.T) {
+	t.Run("without URL returns unset", func(t *testing.T) {
 		t.Setenv("LOKI_URL", "")
-		got, source, err := determineLokiURL(auth.AuthModeKubeConfig, "", false)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if got != defaultLokiURL || source != "default" {
-			t.Fatalf("unexpected result: %s (%s)", got, source)
-		}
-	})
-
-	t.Run("non-kubeconfig without URL returns unset", func(t *testing.T) {
-		t.Setenv("LOKI_URL", "")
-		got, source, err := determineLokiURL(auth.AuthModeHeader, "", false)
+		got, source, err := determineLokiURL("")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}


### PR DESCRIPTION
When the MCP server runs in `kubeconfig` mode inside a Pod, the previous behavior prevented the usage of the `lokiNamespace`/`lokiName` tool parameters, because the default loki URL was used.