### PR TITLE
normalize label copies in anticipation of future dep versions

### DIFF
--- a/pkg/metrics/prometheus/loader.go
+++ b/pkg/metrics/prometheus/loader.go
@@ -238,7 +238,9 @@ func (p *RealLoader) GetLabelNames(ctx context.Context, metricName string, start
 		"duration_ms", duration.Milliseconds(), "result_count", len(labelNames))
 
 	labels := make([]string, len(labelNames))
-	copy(labels, labelNames)
+	for i, name := range labelNames {
+		labels[i] = string(name) //nolint:unconvert // backwards-compatible approach; required in future versions of Prometheus client library
+	}
 	return labels, nil
 }
 


### PR DESCRIPTION
openshift-mcp-server project vendors this library, but does not currently pin prometheus/client_golang and our upstream project (containers/kubernetes-mcp-server) uses v1.24.1.  

In v1.24.0 the API changes here and label names use a structured type instead of a string.  They type is convertible like label values, but requires explicit conversion used in a slice.  

This PR proposes adaption of a future-compatible and backwards-compatible approach to resolve this.  It does require a `nolint` directive to bypass lint in the current version of client_golang. 

We would ask for a new release tag to update the vendoring in openshift-mcp-project. 