### PR TITLE
test: harden Tempo e2e against query-frontend connection flaps

### DIFF
--- a/hack/e2e/setup.sh
+++ b/hack/e2e/setup.sh
@@ -327,6 +327,11 @@ phase_extras() {
         esac
         _wait_rollout tracing statefulset/tempo-tempo1-ingester 5m
         _wait_rollout tracing statefulset/tempo-tempo2-ingester 5m
+        # Query-frontend serves the Tempo HTTP API used by e2e search tests.
+        # Ingester Ready alone is not enough — connection refused on :3200 is a
+        # common flake when tests start before query-frontend is accepting traffic.
+        _wait_rollout tracing deployment/tempo-tempo1-query-frontend 5m
+        _wait_rollout tracing deployment/tempo-tempo2-query-frontend 5m
 
         step "Waiting for traces to appear in Tempo"
         # Just in case the some residual pod stayed there from last attempt.

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -706,21 +706,10 @@ func TestTempoListInstances(t *testing.T) {
 }
 
 func TestTempoSearchTags(t *testing.T) {
-	resp, err := mcpClient.CallTool(t, 23, "tempo_search_tags", map[string]any{
+	resp := callTempoTool(t, 23, "tempo_search_tags", map[string]any{
 		"tempoNamespace": "tracing",
 		"tempoName":      "tempo1",
 	})
-	if err != nil {
-		t.Fatalf("Failed to call tempo_search_tags: %v", err)
-	}
-
-	if resp.Error != nil {
-		t.Fatalf("MCP error: %s", resp.Error.Message)
-	}
-	if isErr, ok := resp.Result["isError"].(bool); ok && isErr {
-		resultJSON, _ := json.Marshal(resp.Result)
-		t.Fatalf("tempo_search_tags returned an error result: %s", resultJSON)
-	}
 
 	structured := resp.Result["structuredContent"].(map[string]any)
 	scopes := structured["scopes"].([]any)
@@ -747,21 +736,11 @@ func TestTempoSearchTags(t *testing.T) {
 }
 
 func TestTempoSearchTraces(t *testing.T) {
-	resp, err := mcpClient.CallTool(t, 40, "tempo_search_traces", map[string]any{
+	resp := callTempoTool(t, 40, "tempo_search_traces", map[string]any{
 		"tempoNamespace": "tracing",
 		"tempoName":      "tempo1",
 		"query":          "{}",
 	})
-	if err != nil {
-		t.Fatalf("Failed to call tempo_search_traces: %v", err)
-	}
-	if resp.Error != nil {
-		t.Fatalf("MCP error: %s", resp.Error.Message)
-	}
-	if isErr, ok := resp.Result["isError"].(bool); ok && isErr {
-		resultJSON, _ := json.Marshal(resp.Result)
-		t.Fatalf("tempo_search_traces returned an error result: %s", resultJSON)
-	}
 
 	structured, ok := resp.Result["structuredContent"].(map[string]any)
 	require.True(t, ok, "expected structuredContent in result")
@@ -797,18 +776,12 @@ func TestTempoSearchTraces_EmptyQuery(t *testing.T) {
 
 func TestTempoGetTraceByID(t *testing.T) {
 	// First retrieve a real trace ID from the search tool.
-	searchResp, err := mcpClient.CallTool(t, 42, "tempo_search_traces", map[string]any{
+	searchResp := callTempoTool(t, 42, "tempo_search_traces", map[string]any{
 		"tempoNamespace": "tracing",
 		"tempoName":      "tempo1",
 		"query":          "{}",
 		"limit":          1,
 	})
-	if err != nil {
-		t.Fatalf("Failed to call tempo_search_traces: %v", err)
-	}
-	if searchResp.Error != nil {
-		t.Fatalf("MCP error during trace search: %s", searchResp.Error.Message)
-	}
 
 	structured, ok := searchResp.Result["structuredContent"].(map[string]any)
 	if !ok {
@@ -826,22 +799,11 @@ func TestTempoGetTraceByID(t *testing.T) {
 
 	t.Logf("Fetching trace %s", traceID)
 
-	// Now fetch that trace by ID.
-	resp, err := mcpClient.CallTool(t, 43, "tempo_get_trace_by_id", map[string]any{
+	resp := callTempoTool(t, 43, "tempo_get_trace_by_id", map[string]any{
 		"tempoNamespace": "tracing",
 		"tempoName":      "tempo1",
 		"traceid":        traceID,
 	})
-	if err != nil {
-		t.Fatalf("Failed to call tempo_get_trace_by_id: %v", err)
-	}
-	if resp.Error != nil {
-		t.Fatalf("MCP error: %s", resp.Error.Message)
-	}
-	if isErr, ok := resp.Result["isError"].(bool); ok && isErr {
-		resultJSON, _ := json.Marshal(resp.Result)
-		t.Fatalf("tempo_get_trace_by_id returned an error result: %s", resultJSON)
-	}
 
 	traceStructured, ok := resp.Result["structuredContent"].(map[string]any)
 	require.True(t, ok, "expected structuredContent in result")
@@ -874,21 +836,11 @@ func TestTempoGetTraceByID_InvalidID(t *testing.T) {
 }
 
 func TestTempoSearchTagValues(t *testing.T) {
-	resp, err := mcpClient.CallTool(t, 45, "tempo_search_tag_values", map[string]any{
+	resp := callTempoTool(t, 45, "tempo_search_tag_values", map[string]any{
 		"tempoNamespace": "tracing",
 		"tempoName":      "tempo1",
 		"tag":            "resource.service.name",
 	})
-	if err != nil {
-		t.Fatalf("Failed to call tempo_search_tag_values: %v", err)
-	}
-	if resp.Error != nil {
-		t.Fatalf("MCP error: %s", resp.Error.Message)
-	}
-	if isErr, ok := resp.Result["isError"].(bool); ok && isErr {
-		resultJSON, _ := json.Marshal(resp.Result)
-		t.Fatalf("tempo_search_tag_values returned an error result: %s", resultJSON)
-	}
 
 	structured, ok := resp.Result["structuredContent"].(map[string]any)
 	require.True(t, ok, "expected structuredContent in result")

--- a/tests/e2e/openshift_e2e_test.go
+++ b/tests/e2e/openshift_e2e_test.go
@@ -182,22 +182,12 @@ func TestTempoListInstances(t *testing.T) {
 }
 
 func TestTempoSearchTraces_Multitenant(t *testing.T) {
-	resp, err := mcpClient.CallTool(t, 40, "tempo_search_traces", map[string]any{
+	resp := callTempoTool(t, 40, "tempo_search_traces", map[string]any{
 		"tempoNamespace": "tracing",
 		"tempoName":      "multitenant",
 		"tenant":         "project1",
 		"query":          "{}",
 	})
-	if err != nil {
-		t.Fatalf("Failed to call tempo_search_traces: %v", err)
-	}
-	if resp.Error != nil {
-		t.Fatalf("MCP error: %s", resp.Error.Message)
-	}
-	if isErr, ok := resp.Result["isError"].(bool); ok && isErr {
-		resultJSON, _ := json.Marshal(resp.Result)
-		t.Fatalf("tempo_search_traces returned an error result: %s", resultJSON)
-	}
 
 	structured, ok := resp.Result["structuredContent"].(map[string]any)
 	require.True(t, ok, "expected structuredContent in result")

--- a/tests/e2e/tempo_helpers.go
+++ b/tests/e2e/tempo_helpers.go
@@ -1,0 +1,60 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	tempoRetryTimeout  = 60 * time.Second
+	tempoRetryInterval = 5 * time.Second
+)
+
+// isTransientBackendError reports whether a tool error result is likely a
+// temporary connectivity failure against the Tempo backend.
+func isTransientBackendError(resultJSON []byte) bool {
+	s := string(resultJSON)
+	return strings.Contains(s, "connection refused") ||
+		strings.Contains(s, "i/o timeout") ||
+		strings.Contains(s, "connection reset") ||
+		strings.Contains(s, "no such host") ||
+		strings.Contains(s, "temporary failure in name resolution") ||
+		strings.Contains(s, "TLS handshake timeout")
+}
+
+// callTempoTool calls a Tempo tool and retries on transient backend connectivity
+// errors. Setup waits for Tempo, but query-frontend can briefly refuse connections
+// after the CR reports Ready.
+func callTempoTool(t *testing.T, id int, toolName string, args map[string]any) *MCPResponse {
+	t.Helper()
+
+	deadline := time.Now().Add(tempoRetryTimeout)
+	var lastResultJSON []byte
+	attempt := 0
+
+	for {
+		attempt++
+		resp, err := mcpClient.CallTool(t, id, toolName, args)
+		if err != nil {
+			t.Fatalf("Failed to call %s: %v", toolName, err)
+		}
+		if resp.Error != nil {
+			t.Fatalf("MCP error from %s: %s", toolName, resp.Error.Message)
+		}
+		if isErr, ok := resp.Result["isError"].(bool); ok && isErr {
+			lastResultJSON, _ = json.Marshal(resp.Result)
+			if isTransientBackendError(lastResultJSON) && time.Now().Before(deadline) {
+				t.Logf("%s attempt %d: transient backend error, retrying in %s: %s",
+					toolName, attempt, tempoRetryInterval, lastResultJSON)
+				time.Sleep(tempoRetryInterval)
+				continue
+			}
+			t.Fatalf("%s returned an error result: %s", toolName, lastResultJSON)
+		}
+		return resp
+	}
+}


### PR DESCRIPTION
After instances without routes are discoverable via service DNS(after #191), search tests can hit connection refused before query-frontend is accepting traffic. Wait for the query-frontend rollout in setup and retry transient backend errors in the Tempo tool tests.

Ref: https://github.com/rhobs/obs-mcp/actions/runs/31161741871

```
--- PASS: TestTempoListInstances (0.01s)
=== RUN   TestTempoSearchTags
    e2e_test.go:722: tempo_search_tags returned an error result: {"content":[{"text":"Get \"[http://tempo-tempo1-query-frontend.tracing.svc:3200/api/v2/search/tags\](http://tempo-tempo1-query-frontend.tracing.svc:3200/api/v2/search/tags/)": dial tcp 10.96.232.244:3200: connect: connection refused","type":"text"}],"isError":true}
--- FAIL: TestTempoSearchTags (0.01s)
=== RUN   TestTempoSearchTraces
    e2e_test.go:763: tempo_search_traces returned an error result: {"content":[{"text":"Get \"http://tempo-tempo1-query-frontend.tracing.svc:3200/api/search?q=%7B%7D\": dial tcp 10.96.232.244:3200: connect: connection refused","type":"text"}],"isError":true}
--- FAIL: TestTempoSearchTraces (0.01s)
=== RUN   TestTempoSearchTraces_EmptyQuery
    e2e_test.go:791: Correctly returned error for empty query
--- PASS: TestTempoSearchTraces_EmptyQuery (0.00s)
=== RUN   TestTempoGetTraceByID
    e2e_test.go:815: No structuredContent in search response; skipping tempo_get_trace_by_id test
--- SKIP: TestTempoGetTraceByID (0.01s)
=== RUN   TestTempoGetTraceByID_InvalidID
    e2e_test.go:865: Correctly returned error for non-existent trace ID
--- PASS: TestTempoGetTraceByID_InvalidID (0.01s)
=== RUN   TestTempoSearchTagValues
    e2e_test.go:890: tempo_search_tag_values returned an error result: {"content":[{"text":"Get \"[http://tempo-tempo1-query-frontend.tracing.svc:3200/api/v2/search/tag/resource.service.name/values\](http://tempo-tempo1-query-frontend.tracing.svc:3200/api/v2/search/tag/resource.service.name/values/)": dial tcp 10.96.232.244:3200: connect: connection refused","type":"text"}],"isError":true}
--- FAIL: TestTempoSearchTagValues (0.02s)
```
