### PR TITLE
RHOBS-1682: redact sensitive headers in debug log output

### DIFF
--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -161,10 +161,20 @@ func authMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+func redactHeaders(h http.Header) http.Header {
+	redacted := h.Clone()
+	for _, key := range []string{"Authorization", "Proxy-Authorization", "Cookie"} {
+		if _, ok := redacted[key]; ok {
+			redacted.Set(key, "[REDACTED]")
+		}
+	}
+	return redacted
+}
+
 func loggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		slog.Info("Incoming request", "method", r.Method, "path", r.URL.Path, "remote_addr", r.RemoteAddr)
-		slog.Debug("Request headers", "headers", r.Header)
+		slog.Debug("Request headers", "headers", redactHeaders(r.Header))
 		if r.ContentLength > 0 {
 			slog.Info("Request content length", "content_length", r.ContentLength)
 		}

--- a/pkg/mcp/server_test.go
+++ b/pkg/mcp/server_test.go
@@ -17,6 +17,69 @@ import (
 	"github.com/rhobs/obs-mcp/pkg/otelcol"
 )
 
+func TestRedactHeaders(t *testing.T) {
+	tests := []struct {
+		name     string
+		headers  http.Header
+		wantKeys map[string]string
+	}{
+		{
+			name: "authorization header is redacted",
+			headers: http.Header{
+				"Authorization": []string{"Bearer secret-token"},
+				"Content-Type":  []string{"application/json"},
+			},
+			wantKeys: map[string]string{
+				"Authorization": "[REDACTED]",
+				"Content-Type":  "application/json",
+			},
+		},
+		{
+			name: "proxy-authorization header is redacted",
+			headers: http.Header{
+				"Proxy-Authorization": []string{"Bearer proxy-token"},
+			},
+			wantKeys: map[string]string{
+				"Proxy-Authorization": "[REDACTED]",
+			},
+		},
+		{
+			name: "cookie header is redacted",
+			headers: http.Header{
+				"Cookie": []string{"session=abc123"},
+			},
+			wantKeys: map[string]string{
+				"Cookie": "[REDACTED]",
+			},
+		},
+		{
+			name: "non-sensitive headers are preserved",
+			headers: http.Header{
+				"Accept":       []string{"text/html"},
+				"Content-Type": []string{"application/json"},
+			},
+			wantKeys: map[string]string{
+				"Accept":       "text/html",
+				"Content-Type": "application/json",
+			},
+		},
+		{
+			name:     "empty headers",
+			headers:  http.Header{},
+			wantKeys: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			redacted := redactHeaders(tt.headers)
+			for key, want := range tt.wantKeys {
+				require.Equal(t, want, redacted.Get(key), "header %s", key)
+			}
+		})
+	}
+}
+
 func TestAuthMiddleware(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
The loggingMiddleware logged the entire request header map at debug level, exposing Authorization bearer tokens, cookies, and proxy credentials in pod logs. Clone and redact sensitive headers before logging.


Assisted-by: Claude Code:claude-opus-4-6